### PR TITLE
use componentWithMDXScope

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,6 @@ module.exports = {
       resolve: 'gatsby-mdx',
       options: {
         root: __dirname,
-        hastPlugins: [[prism, { ignoreMissing: true }]],
       },
     },
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,7 @@
 const path = require('path')
 const { createFilePath } = require('gatsby-source-filesystem');
+const componentWithMDXScope = require("gatsby-mdx/component-with-mdx-scope");
+
 
 
 async function makePostsFromMdx({ graphql, actions }) {
@@ -12,6 +14,9 @@ async function makePostsFromMdx({ graphql, actions }) {
             node {
               fields {
                 slug
+              }
+              code {
+                scope
               }
               frontmatter {
                 title
@@ -28,7 +33,7 @@ async function makePostsFromMdx({ graphql, actions }) {
   posts.forEach(post => {
     actions.createPage({
       path: post.node.fields.slug,
-      component: blogPost,
+      component: componentWithMDXScope(blogPost, post.node.code.scope),
       context: {
         slug: post.node.fields.slug,
       },

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -75,7 +75,7 @@ import { isFunction } from 'util';
 // export default BlogPostTemplate
 
 export const pageQuery = graphql`
-  query BlogPostBySlug($slug: String!) {
+  query($slug: String!) {
     site {
       siteMetadata {
         title


### PR DESCRIPTION
Remove extra prism processing that was causing another error. I'd suggest using [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer) as the `code` component in your MDXProvider rather than the rehype-prism plugin. (there does seem to be something applying highlighting even now, but I didn't take the time to figure out what else is included in the site that may be causing that).

Remove name from graphql query so that it's hashed appropriately automatically (see issue https://github.com/ChristopherBiscardi/gatsby-mdx/issues/188 if you're interested in why that is for now).