### PR TITLE
add null check for entry.borderBoxSize

### DIFF
--- a/src/utils/useRowFinder.js
+++ b/src/utils/useRowFinder.js
@@ -11,7 +11,14 @@ export default function useRowFinder() {
   // when the nav changes size, run this callback
   function callback([entry]) {
     // if there is nothing, skip it
-    if (!entry || !entry.target || !entry.target.children) return;
+    if (
+      !entry ||
+      !entry.target ||
+      !entry.target.children ||
+      !entry.borderBoxSize
+    ) {
+      return;
+    }
     // if the width has not changed, skip it
     const width = entry.borderBoxSize.inlineSize;
     if (width === previous.current.width && previous.current.renders >= 2) {


### PR DESCRIPTION
I got the following error in Google Chrome (Version 80.0.3987.132 (Official Build) (64-bit)):

```
ResizeObserver.callback
src/utils/useRowFinder.js:16
  13 | // if there is nothing, skip it
  14 | if (!entry || !entry.target || !entry.target.children) return;
  15 | // if the width has not changed, skip it
> 16 | const width = entry.borderBoxSize.inlineSize;
  17 | if (width === previous.current.width && previous.current.renders >= 2) {
  18 |   // console.log('Same width, skipping');
  19 |   previous.current.renders = 0;
```

The error did not occured in Firefox.