### PR TITLE
fix: use prebuild to always install functions deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "build": "gatsby-parallel-runner",
     "netlify": "netlify dev",
     "deploy": "gatsby-parallel-runner --prefix-paths && gh-pages -d public",
-    "postinstall": "netlify-lambda install",
+    "prebuild": "netlify-lambda install",
     "scrape": "NODE_OPTIONS='--inspect=localhost:4444 -r esm' node scrape-tips.js"
   }
 }


### PR DESCRIPTION
Feel free to close this if it’s not what you want, but this will make sure that the functions install step _always_ runs, even if a cache is found and no `install` step runs.