### PR TITLE
Upgrade gatsby-plugin-prettier-build to 0.4.1

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,7 +18,9 @@ module.exports = {
     {
       resolve: `gatsby-plugin-prettier-build`,
       options: {
-        types: ['html'], // default value
+        types: ['html'],
+        concurrency: 20,
+        verbose: true,
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gatsby-plugin-mdx": "^1.0.79",
     "gatsby-plugin-nprogress": "^2.1.20",
     "gatsby-plugin-offline": "^3.0.39",
-    "gatsby-plugin-prettier-build": "^0.1.0",
+    "gatsby-plugin-prettier-build": "^0.4.1",
     "gatsby-plugin-react-helmet": "^3.1.23",
     "gatsby-plugin-sharp": "^2.4.10",
     "gatsby-plugin-styled-components": "^3.1.20",


### PR DESCRIPTION
Implements concurrency as-per https://github.com/jmsv/gatsby-plugin-prettier-build/issues/1

~PRing to see if it works on CI~ nevermind, looks like netlify previews aren't on? 