### PR TITLE
Update Tagged Template Literals.mdx

### DIFF
--- a/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
+++ b/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
@@ -124,7 +124,7 @@ You can use whatever loop or logic you prefer inside of this function. You could
 
 
 ```js
-function highlight() {
+function highlight(strings, ...values) {
    let str = '';
    strings.forEach((string, i) => {
        str += string + values[i];
@@ -148,7 +148,7 @@ A little trick you can do here, is you can use your values of I or just a blank 
 
 
 ```js
-function highlight() {
+function highlight(strings, ...values) {
    let str = '';
    strings.forEach((string, i) => {
        str += string + (values[i] || '');
@@ -167,10 +167,10 @@ You maybe want to show your user which pieces of the string were variables or wh
 
 
 ```js
-function highlight() {
+function highlight(strings, ...values) {
    let str = '';
    strings.forEach((string, i) => {
-       str += `${string} <span class='hl'>${values[i] || ''}`;
+       str += `${string} <span class='hl'>${values[i] || ''}</span>`;
    });
    return str;
 }


### PR DESCRIPTION
While trying out provided examples, it turned out that some of them don't work.

The proposed fixes make if possible to run without 
"ReferenceError: strings is not defined"
"ReferenceError: values is not defined"
errors.

And there is an added closing </span> tag in the last example.