### PR TITLE
🕷 Bugfix - Fix double trailing slashes in canonical and twitter:url

### DIFF
--- a/src/components/MetaTags.js
+++ b/src/components/MetaTags.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { pathJoin } from '../utils/path-join';
 
 function getBaseURL() {
   const url = process.env.GATSBY_URL;
@@ -13,8 +14,8 @@ function getBaseURL() {
 const baseURL = getBaseURL();
 
 export function PostMetaTags({ post }) {
-  const canonical = `https://wesbos.com/${post.frontmatter.slug}`;
-  const url = `${baseURL}/${post.frontmatter.slug}`;
+  const canonical = pathJoin('https://wesbos.com', post.frontmatter.slug);
+  const url = pathJoin(baseURL, post.frontmatter.slug);
   const thumbnailData = {
     title: post.frontmatter.title,
     url,

--- a/src/utils/path-join.js
+++ b/src/utils/path-join.js
@@ -1,0 +1,13 @@
+// helper function from https://stackoverflow.com/questions/29855098/is-there-a-built-in-javascript-function-similar-to-os-path-join
+export const pathJoin = (...args) => {
+  return args
+    .map((part, i) => {
+      if (i === 0) {
+        return part.trim().replace(/[\/]*$/g, '');
+      } else {
+        return part.trim().replace(/(^[\/]*|[\/]*$)/g, '');
+      }
+    })
+    .filter((x) => x.length)
+    .join('/');
+};


### PR DESCRIPTION
Replaces single and double trailing slashes with un-suffixed URL's for `canonical` and `twitter:url`

## Before

![image](https://user-images.githubusercontent.com/3408480/80322969-4eaebb00-87f6-11ea-8ac2-db4cb63ba344.png)

## After

![image](https://user-images.githubusercontent.com/3408480/80322976-638b4e80-87f6-11ea-91c9-ba49e7f20954.png)
![image](https://user-images.githubusercontent.com/3408480/80322985-77cf4b80-87f6-11ea-966c-f234a8a8a6ab.png)

