### PR TITLE
fix: Enable embedded tweets

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,6 +28,7 @@ module.exports = {
         name: 'page',
       },
     },
+    `gatsby-plugin-twitter`,
     // Posts
     {
       resolve: `gatsby-source-filesystem`,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gatsby-plugin-remove-trailing-slashes": "^2.2.3",
     "gatsby-plugin-sharp": "^2.5.6",
     "gatsby-plugin-styled-components": "^3.2.3",
+    "gatsby-plugin-twitter": "^2.3.0",
     "gatsby-remark-autolink-headers": "^2.2.3",
     "gatsby-remark-copy-linked-files": "^2.2.3",
     "gatsby-remark-images": "^3.2.4",


### PR DESCRIPTION
https://wesbos.com/wordpress-calypso-react has the blockquote, but not the embedded tweet

I fixed this by adding [`gatsby-plugin-twitter`](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-twitter)