### PR TITLE
Fix assignment typo

### DIFF
--- a/src/posts/ES6 let VS const variables/ES6 let VS const variables.mdx
+++ b/src/posts/ES6 let VS const variables/ES6 let VS const variables.mdx
@@ -97,7 +97,7 @@ const key = 'abc123';
 let points = 50;
 let winner = false;
 
-key = abc1234;
+key = 'abc1234';
 
 ```
 


### PR DESCRIPTION
The assignment has missing quotes, the second change is most likely because the emoji got edited while editing on mobile (maintainer edits are on, so you can just cherry pick it away) 