### PR TITLE
TYPO: fix spelling of milliseconds.

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -67,7 +67,7 @@ export default function AboutPage({ data, path }) {
           making websites
         </a>{' '}
         for about {timeAsYears} years - or <em>exactly</em>{' '}
-        <TimeSinceStarting /> miliseconds!
+        <TimeSinceStarting /> milliseconds!
       </p>
 
       <p>


### PR DESCRIPTION
Hey Wes, love the tutorials and the podcast.

Spotted this typo whilst browsing your about page. 

Have a good one!