### PR TITLE
fix naming of gatsby-remark-embedder plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,7 +57,7 @@ module.exports = {
       options: {
         root: __dirname,
         gatsbyRemarkPlugins: [
-          `gatsby-plugin-embedder`,
+          `gatsby-remark-embedder`,
           `gatsby-remark-copy-linked-files`,
           {
             resolve: 'gatsby-remark-vscode',
@@ -90,7 +90,7 @@ module.exports = {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [
-          `gatsby-plugin-embedder`,
+          `gatsby-remark-embedder`,
           {
             resolve: `gatsby-remark-images`,
             options: {


### PR DESCRIPTION
as mentioned in https://github.com/wesbos/wesbos/pull/73#issuecomment-633657813