### PR TITLE
Add error handling to paginate function

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -112,11 +112,9 @@ async function paginate({
       }
     `
   );
-
   if (errors) {
     throw new Error('There was an error');
   }
-
   const { totalCount } = data.allMdx;
   const pages = Math.ceil(totalCount / 10);
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -113,6 +113,10 @@ async function paginate({
     `
   );
 
+  if (errors) {
+    throw new Error('There was an error');
+  }
+
   const { totalCount } = data.allMdx;
   const pages = Math.ceil(totalCount / 10);
 


### PR DESCRIPTION
The variable, `errors`, was being destructured from the graphql query on `line 106` in `gatsby-node.js`, but was never used. Following the same pattern of error handling in that file, I added it to the paginate function. 