### PR TITLE
Handle caption being an empty array

### DIFF
--- a/functions/instagram.js
+++ b/functions/instagram.js
@@ -26,7 +26,10 @@ function slimUpPosts(response) {
     biggie: edge.node.thumbnail_src,
     thumbnail: edge.node.thumbnail_resources[2].src,
     url: `https://instagram.com/p/${edge.node.shortcode}`,
-    caption: edge.node.edge_media_to_caption.edges[0].node.text,
+    caption:
+      edge.node.edge_media_to_caption.edges.length > 0
+        ? edge.node.edge_media_to_caption.edges[0].node.text
+        : null,
     id: edge.node.id,
   }));
 }


### PR DESCRIPTION
If no caption is provided then we get a `TypeError` and the script breaks the page. 

There's probably something better to return here than `null` but this works as a quick fix for what is generally an edge case.