### PR TITLE
Fix code block boundaries in ES6 posts

### DIFF
--- a/src/posts/4 New String Methods in ES6 that you should know/4 New String Methods in ES6 that you should know.mdx
+++ b/src/posts/4 New String Methods in ES6 that you should know/4 New String Methods in ES6 that you should know.mdx
@@ -13,18 +13,18 @@ The String type in ES6 has come with **four new methods** that are really handy,
 
 <h3>.startsWith() and .endsWith()</h3>
 
-So I have a `const variable named course, which has the value of RFB1`, this stands for React for Beginners.
+So I have a `const` variable named `course`, which has the value of `RFB1`, this stands for React for Beginners.
 
 
 ```js
 const course = 'RFB1';
 ```
 
-Sometimes I have `RFB1 which is the starter package, RFB2 which is the master package, RFB3 which is the team package. I don't really care too much about that in certain cases, I just want to know if course starts with RFB, and not something like STPU, which is Sublime Text Power User or ES6`, which is this series.
+Sometimes I have `RFB1` which is the starter package, `RFB2` which is the master package, `RFB3` which is the team package. I don't really care too much about that in certain cases, I just want to know if course starts with `RFB`, and not something like `STPU`, which is Sublime Text Power User or `ES6`, which is this series.
 
-Here, `RFB means React for Beginners, I need to know if the string starts with it. We can use the console to check this out by typing course.startsWith('RFB'), it will return true`, because obviously it does start with it.
+Here, `RFB` means React for Beginners, I need to know if the string starts with it. We can use the console to check this out by typing `course.startsWith('RFB')`, it will return `true`, because obviously it does start with it.
 
-If I did `rfb, in lowercase letters, it says, false`, because there is no way to make this case insensitive. If you do need case sensitivity you must still use a Regular Expression.
+If I did `rfb`, in lowercase letters, it says, `false`, because there is no way to make this case insensitive. If you do need case sensitivity you must still use a Regular Expression.
 
 One other thing that `.startsWith()`  will do is it'll allow you to skip a certain number of characters and start looking at a set point.
 
@@ -33,11 +33,11 @@ One other thing that `.startsWith()`  will do is it'll allow you to skip a certa
 const flightNumber = '20-AC2018-jz';
 ```
 
-This flight number here, I want to see if it starts with `AC. Over in the console, I'm going to type flightNumber.startsWith('AC'). It's false, because the variable starts with 20-`. This also happens if we have SKU numbers, and they start with a bunch of junk and then it gets to actually what we want.
+This flight number here, I want to see if it starts with `AC`. Over in the console, I'm going to type `flightNumber.startsWith('AC')`. It's `false`, because the variable starts with `20-`. This also happens if we have SKU numbers, and they start with a bunch of junk and then it gets to actually what we want.
 
-What you can do is you can use `flightNumber.startsWith('AC', 3);, which says start after three characters. That is returning true`, because it ignores the first three and then starts at AC and checks against that.
+What you can do is you can use `flightNumber.startsWith('AC', 3);`, which says start after three characters. That is returning `true`, because it ignores the first three and then starts at AC and checks against that.
 
-`EndsWith works fairly similar. Here is an example where we have jz at the end of the flightNumber, and I want to know if it's an Air Canada Jazz flight. We can say flightNumber.endsWith('jz'), which will be true`, obviously, because it ends with it.
+`EndsWith` works fairly similar. Here is an example where we have jz at the end of the flightNumber, and I want to know if it's an Air Canada Jazz flight. We can say `flightNumber.endsWith('jz')`, which will be `true`, obviously, because it ends with it.
 
 There's another option that we can pass `.endsWith()`, and I'm going to use an account number variable as an example here:
 
@@ -52,17 +52,17 @@ Then you have a tax number, which is RT0001, or RT0002. You also might have RP00
 
 I need to check if this number, which ends with RT, and I want to ignore this right here. What you can do is you can tell the account number to just take a certain number of characters, and ignore the rest.
 
-Just like with our `flightNumber, we can use the console to put in accountNumber.endsWith('RT'), which will be false. What I can tell it, though, is only take the first 11 numbers, by using accountNumber.endsWith('RT', 11); which will be true`.
+Just like with our `flightNumber`, we can use the console to put in `accountNumber.endsWith('RT')`, which will be `false`. What I can tell it, though, is only take the first 11 numbers, by using `accountNumber.endsWith('RT', 11);` which will be `true`.
 
 Essentially you're just going to take the first 11 numbers of `accountNumber`, ignore the rest, and then see if it ends in RT or whatever else it might be.
 
 <h3>.includes()</h3>
 
-Then next up we have `.includes() which will just check if that string is anywhere in it. If I wanted to see if my flight number includes the letters AC, then I could use flightNumber.includes('AC'), which is true`.
+Then next up we have `.includes()` which will just check if that string is anywhere in it. If I wanted to see if my flight number includes the letters AC, then I could use `flightNumber.includes('AC')`, which is `true`.
 
 Again, it is not case sensitive so you cannot use lower case letters here.
 
-`.includes() checks to see if your string has something in it. As a bit of an aside, it was originally supposed to be called .contains()`, but it got changed to includes because of some conflicts with the MooTool libraries and the way that they modified the prototype.
+`.includes()` checks to see if your string has something in it. As a bit of an aside, it was originally supposed to be called `.contains()`, but it got changed to includes because of some conflicts with the MooTool libraries and the way that they modified the prototype.
 
 <h3>.repeat() and String Padding</h3>
 
@@ -75,9 +75,9 @@ const model = 'x5';
 const colour = 'Royal Blue';
 ```
 
-I'm going to show you where that would be useful for using `.repeat(), which allows you to take a string, and repeat it. You can just call .repeat()` and it's going to repeat that string over and over and over again.
+I'm going to show you where that would be useful for using `.repeat()`, which allows you to take a string, and repeat it. You can just call `.repeat()` and it's going to repeat that string over and over and over again.
 
-Where is that useful? Sometimes we have some words here. I'm going to take my `BMW, x5 and royal blue`, and if I wanted to display the variables in a terminal or something, but I want to right align them. How would that work? I'd have to just put a whole bunch of padding in, depending on how long this was and how much space will be used, kind of like this:
+Where is that useful? Sometimes we have some words here. I'm going to take my `BMW`, `x5` and `royal blue`, and if I wanted to display the variables in a terminal or something, but I want to right align them. How would that work? I'd have to just put a whole bunch of padding in, depending on how long this was and how much space will be used, kind of like this:
 
 
 ```js
@@ -86,7 +86,7 @@ Where is that useful? Sometimes we have some words here. I'm going to take my `B
           Royal Blue
 ```
 
-What we can do, instead of hitting the space bar each time, we can use a left pad function, and you can use `.repeat()`to code a nice little left padding function.
+What we can do, instead of hitting the space bar each time, we can use a left pad function, and you can use `.repeat()` to code a nice little left padding function.
 
 Here we can `return` a string, and we need to then pad it with however many characters we need. We'll take a space and repeat it 10 times.
 
@@ -101,7 +101,7 @@ console.log(leftPad(model));  // '          x5'
 console.log(leftPad(colour)); // '          Royal Blue'
 ```
 
-However, if we want it right aligned, we'll need to subtract however many characters are in the string, so we subtract `str.length here before we return the actual string itself in ${str}`;
+However, if we want it right aligned, we'll need to subtract however many characters are in the string, so we subtract `str.length` here before we return the actual string itself in `${str}`;
 
 
 ```js
@@ -110,7 +110,7 @@ leftPad = function(str, length = 20){
 }
 ```
 
-I can take make, model, and color, put them in here. It's going to console.log each one of them out. I'm going to leave out the length because we're going to default it to 20, and it should just pass in the make, model, and color.
+I can take `make`, `model`, and `color`, put them in here. It's going to `console.log` each one of them out. I'm going to leave out the length because we're going to default it to 20, and it should just pass in the make, model, and color.
 
 
 ```js
@@ -119,7 +119,7 @@ console.log(leftPad(model));  // '                  x5'
 console.log(leftPad(colour)); // '          Royal Blue'
 ```
 
-There we go. See how all these are perfectly right aligned? BMW X5 in royal blue, whereas all of this is however much padding we actually need. That's a nice little use for repeat.
+There we go. See how all these are perfectly right aligned? `BMW`, `X5` and `royal blue`, whereas all of this is however much padding we actually need. That's a nice little use for repeat.
 
 <h3>Very Important</h3>
 

--- a/src/posts/A Dead Simple intro to Destructuring JavaScript Objects/A Dead Simple intro to Destructuring JavaScript Objects.mdx
+++ b/src/posts/A Dead Simple intro to Destructuring JavaScript Objects/A Dead Simple intro to Destructuring JavaScript Objects.mdx
@@ -39,7 +39,7 @@ const { first, last } = person;
 
 Curly bracket on the left of the equals sign?! That is not a block. That is not an object. It's the new destructuring syntax.
 
-The above code says, give me a variable called **first**, a variable called **last**, and take it from the `person object. We're taking the first property and the last` property and putting them into two new variables that will be scoped to the parent block (or window!).
+The above code says, give me a variable called **first**, a variable called **last**, and take it from the `person` object. We're taking the `first` property and the `last` property and putting them into two new variables that will be scoped to the parent block (or window!).
 
 
 ```js
@@ -47,7 +47,7 @@ console.log(first); // Wes
 console.log(last); // Bos
 ```
 
-Similarly, if I also wanted twitter, I would just add twitter into that, and I would get a third top level variable inside of my actual scope `const { first, last, twitter } = person;`
+Similarly, if I also wanted `twitter`, I would just add `twitter` into that, and I would get a third top level variable inside of my actual scope `const { first, last, twitter } = person;`
 
 That's really handy in many use cases. This is just one nested level, but for example, in React.js often you want to use destructuring because the data is so deeply nested in props or state.
 
@@ -87,4 +87,4 @@ const { twitter, facebook } = wes.links.social;
 console.log(twitter, facebook); // logs the 2 variables
 ```
 
-Notice how we destructure `wes.links.social and not just wes`? That is important because we are destructuring a few levels deep.
+Notice how we destructure `wes.links.social` and not just `wes`? That is important because we are destructuring a few levels deep.

--- a/src/posts/An Intro to Template Strings/An Intro to Template Strings.mdx
+++ b/src/posts/An Intro to Template Strings/An Intro to Template Strings.mdx
@@ -36,10 +36,10 @@ console.log(sentence);
 
 ```
 
-That is going to pop in, or <em>interpolate</em>, the `name and age` variables that we previously had set there by using $, curly brackets and the variable name.
+That is going to pop in, or <em>interpolate</em>, the `name` and `age` variables that we previously had set there by using $, curly brackets and the variable name.
 
 You can also run JavaScript straight away inside of these curly brackets, too. You can add in a variable, you can run a function, you can run any JavaScript inside of the curly brackets — including more template strings, but we will talk more about that later.
 
-I'm calculating the age in dog years right inside of `sentence by using ${age * 7}, so our console.log  will just show a regular sentence, My dog Snickers is 14 years old.`
+I'm calculating the age in dog years right inside of `sentence` by using `${age * 7}`, so our `console.log`  will just show a regular sentence, `My dog Snickers is 14 years old.`
 
 That's a very basic overview of template strings. However there's quite a bit more that we can do with them. It can be very handy other than just being able to stick variables inside of it — see you in the next one!

--- a/src/posts/ES6 Block Scope is The new IIFE/ES6 Block Scope is The new IIFE.mdx
+++ b/src/posts/ES6 Block Scope is The new IIFE/ES6 Block Scope is The new IIFE.mdx
@@ -9,7 +9,7 @@ date: 2016-08-31T22:20:16
 id: 3810
 ---
 
-You can probably see where `let and const` are going to be useful: **if you need to scope something to a block**, or **if you want to make a variable that cannot be changed** by accident or on purpose.
+You can probably see where `let` and `const` are going to be useful: **if you need to scope something to a block**, or **if you want to make a variable that cannot be changed** by accident or on purpose.
 
 Let's take a look at a couple of more examples of when it might be useful.
 
@@ -17,7 +17,7 @@ The first one is replacing the **Immediately-Invoked Function Expression**, or *
 
 An IIFE function runs itself immediately, and it creates a scope where nothing is going to leak into the parent scope. In our case, nothing is going to leak into the global scope of the window.
 
-If I have a `var variable: var name = 'wes'`
+If I have a `var` variable: `var name = 'wes'`
 
 You can call that in the console, and that's fine here. However, the window already has a `name` attribute, which is needed when you have a window opening up a another window.
 
@@ -37,13 +37,13 @@ These variables are now scoped to the IIFE function, and because `var` variables
 
 If you try to call `name` in the console now, it's not undefined, it's blank because, like I mentioned, it's just blank because that is a property that lives on the window natively in JavaScript.
 
-If I needed to access our function's `name, obviously, I'd have to do a console.log` inside of the IIFE function, but the important thing is that it's no longer leaking into the global scope.
+If I needed to access our function's `name`, obviously, I'd have to do a `console.log` inside of the IIFE function, but the important thing is that it's no longer leaking into the global scope.
 
-With `let and const` variables, we don't need a function for our variables to be scoped to that.
+With `let` and `const` variables, we don't need a function for our variables to be scoped to that.
 
-Why? Because `let and const` use **block scope**.
+Why? Because `let` and `const` use **block scope**.
 
-Let's start over with a `const instead of a var`
+Let's start over with a `const` instead of a `var`
 
 
 ```js
@@ -62,7 +62,7 @@ const name = 'wes';
 
 ```
 
-Our `const is going to be scoped to that block. If you try to call name in the console, we'll get the window's name, which is blank. But if we add a console.log` to our block:
+Our `const` is going to be scoped to that block. If you try to call name in the console, we'll get the window's `name`, which is blank. But if we add a `console.log` to our block:
 
 
 ```js
@@ -74,4 +74,4 @@ console.log(name);
 
 ```
 
-...we'll get `wes in the console. You don't the IIFE stuff anymore. You're using let and const` because they are going to be scoped to that block.
+...we'll get `wes` in the console. You don't the IIFE stuff anymore. You're using `let` and `const` because they are going to be scoped to that block.

--- a/src/posts/ES6 let VS const variables/ES6 let VS const variables.mdx
+++ b/src/posts/ES6 let VS const variables/ES6 let VS const variables.mdx
@@ -11,7 +11,7 @@ id: 3806
 
 In the last post we learned all about how scoping works with <a href="http://wesbos.com/javascript-scoping/">JavaScript let, const and var variables</a>.
 
-We now know that `var is **function scope**, and now we know that let and const` are **block scope**, which means any time you've got a set of curly brackets you have block scope.
+We now know that `var` is **function scope**, and now we know that `let` and `const` are **block scope**, which means any time you've got a set of curly brackets you have block scope.
 
 Now, we need to know **you can only declare a variable inside of its scope once**.
 
@@ -35,7 +35,7 @@ The browser says **points has already been declared**.
 
 However, with `var`, it will just go ahead and declare the variable, which can cause a lot of bugs, because you might accidentally use the same variable twice.
 
-You <em>can</em> **update** a `let variable, and we'll take a look more at let and const` but you <em>cannot</em> redeclare it twice in the same scope.
+You <em>can</em> **update** a `let` variable, and we'll take a look more at `let` and `const` but you <em>cannot</em> redeclare it twice in the same scope.
 
 Now, what if I had this?
 
@@ -51,21 +51,21 @@ if(points > 40) {
 
 ```
 
-If we type in the console, `winner will come back as false. We can add a Console.log line to prove that it runs, but why is winner still false, if we set winner to be true`?
+If we type in the console, `winner` will come back as `false`. We can add a `console.log` line to prove that it runs, but why is `winner` still `false`, if we set winner to be `true`?
 
 The important thing here is that these two `winner` variables are actually **two separate variables**. They have the same name, but they are both **scoped** differently:
 
 
 
-* `let winner = false` outside of the if loop is scoped to the window.
+* `let winner = false` outside of the `if` loop is scoped to the window.
 
-* `let winner = true` inside the if loop is scoped to the block.
+* `let winner = true` inside the `if` loop is scoped to the block.
 
 
 
-If I change our `let winner to be var winner, they'll come back as true, because it's not inside of a function, it's not scoped to it, whereas a let` variable is.
+If I change our `let winner` to be `var winner`, they'll come back as `true`, because it's not inside of a function, it's not scoped to it, whereas a `let` variable is.
 
-The other thing we need to know about it is that the difference between `let and const is that const` variables **cannot be updated**.
+The other thing we need to know about it is that the difference between `let` and `const` is that `const` variables **cannot be updated**.
 
 `let` variables are made to be updated. I may say:
 
@@ -81,7 +81,7 @@ points = 60;
 
 ..and that will work just fine.
 
-However, I've got that `key variable, maybe something that you do not want to ever change, we can use a const`, which stands for **constant**.
+However, I've got that `key` variable, maybe something that you do not want to ever change, we can use a `const`, which stands for **constant**.
 
 
 ```js
@@ -101,7 +101,7 @@ key = 'abc1234';
 
 ```
 
-That won't work because you cannot update a `const variable, whereas you can update a let` variable.
+That won't work because you cannot update a `const` variable, whereas you can update a `let` variable.
 
 We're going to go more into examples of these and you're going to understand which one to use as we go through, but that's really all we need to know about it for now.
 
@@ -116,7 +116,7 @@ const person = {
 
 ```
 
-...and if I try to update something in the `const object by typing person = { name: 'Wesley' }` it won't allow me to do that.
+...and if I try to update something in the `const` object by typing `person = { name: 'Wesley' }` it won't allow me to do that.
 
 However, the properties of a `const` variable <em>can</em> change. That's because the entire object is not immutable. It just can't be reassigned entirely.
 
@@ -147,4 +147,4 @@ const wes = Object.freeze(person);
 
 ```
 
-If I try to update `Wes.age = 30, it will still say 28` 👌
+If I try to update `Wes.age = 30`, it will still say `28` 👌

--- a/src/posts/Easy Creation of HTML with JavaScripts Template Strings/Easy Creation of HTML with JavaScripts Template Strings.mdx
+++ b/src/posts/Easy Creation of HTML with JavaScripts Template Strings/Easy Creation of HTML with JavaScripts Template Strings.mdx
@@ -45,7 +45,7 @@ const markup = `
 
 You can see how this is so much nicer to look at. You <em>will</em> get the whitespace included in the string, but since we're just creating HTML markup, it doesn't really matter.
 
-Now, I can take this string and go ahead and dump it into an existing element in an HTML page. Just for sake of an example, you can use a blank page where the only existing element that we have on the page is the `document.body, and then we can set our markup variable as the inner.HTML`:
+Now, I can take this string and go ahead and dump it into an existing element in an HTML page. Just for sake of an example, you can use a blank page where the only existing element that we have on the page is the `document.body`, and then we can set our markup variable as the `innerHTML`:
 
 
 ```js
@@ -62,7 +62,7 @@ const markup = `
 document.body.innerHTML = markup;
 ```
 
-You could also use `document.createElement to create an element, set the inner.HTML`, and then append that to the body, whatever you like, which is the same with markup.
+You could also use `document.createElement` to create an element, set the `innerHTML`, and then append that to the body, whatever you like, which is the same with markup.
 
 When we refresh the page you see "Wes, web developer, Hamilton, really cool guy," and so on, all on their own individual lines.
 
@@ -85,7 +85,7 @@ const dogs = [
 ];
 ```
 
-Let's use a template string, and create an unordered list with the class of `dogs, and inside of that I want a list item for each one. But I can't, I can't just do something like ${dogs[0].name}` because that would be cheating and that's not really scalable. So how would I loop over every single one?
+Let's use a template string, and create an unordered list with the class of `dogs`, and inside of that I want a list item for each one. But I can't, I can't just do something like `${dogs[0].name}` because that would be cheating and that's not really scalable. So how would I loop over every single one?
 
 We can nest template strings right inside of it. How do we do that? Let's take a look here:
 
@@ -99,7 +99,7 @@ const markup = `
 `;
 ```
 
-Here we are using a template string inside of a template string, so we're going to return a list item, inside of that actual list item we are going to use `${dog.name} and we're going to say how old they are in dog years, which is ${dog.age *7}`.
+Here we are using a template string inside of a template string, so we're going to return a list item, inside of that actual list item we are going to use `${dog.name}` and we're going to say how old they are in dog years, which is `${dog.age *7}`.
 
 Now we've got all this markup here. Let's use `console.log`, and see where we're at. You should see:
 
@@ -113,7 +113,7 @@ Now we've got all this markup here. Let's use `console.log`, and see where we're
 
 ```
 
-But we have that comma in there, so how do you get rid of that? We know that `map will return an array, so we can simply just use join` and an empty string, which will join it without the commas:
+But we have that comma in there, so how do you get rid of that? We know that `map` will return an array, so we can simply just use `join` and an empty string, which will join it without the commas:
 
 
 ```js
@@ -146,7 +146,7 @@ const markup = `
 
 <h3>Conditional If Statements with Template Strings</h3>
 
-Let's look at an example where we need an `if statement inside of our template string. This is taken straight from how you do if` statements inside of a React render template, and that is with a ternary operator.
+Let's look at an example where we need an `if` statement inside of our template string. This is taken straight from how you do `if` statements inside of a React render template, and that is with a ternary operator.
 
 Here I've got a song, some data with a name and an artist:
 
@@ -159,7 +159,7 @@ const song = {
 };
 ```
 
-We always have a `name of the song and the artist of the song, but sometimes we've got a featuring artist. If there is a featuring, we need to include it in our markup so we can add it to our document.body.innerHTML` like this:
+We always have a `name` of the song and the artist of the song, but sometimes we've got a featuring artist. If there is a featuring, we need to include it in our markup so we can add it to our `document.body.innerHTML` like this:
 
 
 ```js
@@ -175,9 +175,9 @@ const markup = `
 document.body.innerHTML = markup;
 ```
 
-If you load that, you'll see `Dying to Live - Tupac (Featuring Biggie Smalls).
+If you load that, you'll see `Dying to Live - Tupac (Featuring Biggie Smalls)`.
 
-That works, but what if we delete `Biggie Smalls`, we get  `(Featuring undefined).
+That works, but what if we delete `Biggie Smalls`, we get  `(Featuring undefined)`.
 
 If it's not there, we don't want the parentheses or the word "Featuring," or anything there. A way we can get around that is by using a **ternary operator**. Our ternary operator will say if "this" then "that", otherwise nothing:
 
@@ -223,7 +223,7 @@ const markup = `
 document.body.innerHTML = markup;
 ```
 
-Just like you'd expect, in your HTML you'll get the beer name and the beer brewery, and that's all wrapped appropriately in `<h2> and a  tags, and it's looking pretty good. But what if I want to implement our array of keywords that's nested inside of the actual beer object? I could just go ahead and do map right on one line, but I'd rather kick it off to a separate function, which I'll call renderKeywords`:
+Just like you'd expect, in your HTML you'll get the beer name and the beer brewery, and that's all wrapped appropriately in `<h2>` and `p` tags, and it's looking pretty good. But what if I want to implement our array of keywords that's nested inside of the actual beer object? I could just go ahead and do map right on one line, but I'd rather kick it off to a separate function, which I'll call `renderKeywords`:
 
 
 ```js

--- a/src/posts/How let and const are scoped in JavaScript/How let and const are scoped in JavaScript.mdx
+++ b/src/posts/How let and const are scoped in JavaScript/How let and const are scoped in JavaScript.mdx
@@ -9,12 +9,12 @@ date: 2016-08-30T13:35:56
 id: 3800
 ---
 
-There are a couple new ways to declare variables in ES6 that help us out with scoping. We can declare variables with `var, which we've always used, but now we can use let and const`
+There are a couple new ways to declare variables in ES6 that help us out with scoping. We can declare variables with `var`, which we've always used, but now we can use `let` and `const`
 to declare variables too.
 
-These two have some attributes about them which are going to be helpful for us in creating variables but let's do a quick review to show you  how `var, let, and const` are different.
+These two have some attributes about them which are going to be helpful for us in creating variables but let's do a quick review to show you  how `var`, `let`, and `const` are different.
 
-Firstly, `var` variables can be **redefined** or **updated**. Let's use console.log to show the width which we can update the width to be 200, and then we'll console log the width again.
+Firstly, `var` variables can be **redefined** or **updated**. Let's use `console.log` to show the width which we can update the width to be 200, and then we'll console log the width again.
 
 
 ```js
@@ -25,11 +25,11 @@ console.log(width); // 200
 
 ```
 
-If you run this in your browser, you'll see we get 100, 200, which isn't a big deal. We're able to update them. You can also put a `var in front of line 3 if you were to accidentally redeclare the variable. If you do, it won't do anything. It will work as you'd expect, but it won't yell at you for creating the same variable name twice in the same scope because var` variables can be **updated** or **redefined**.
+If you run this in your browser, you'll see we get 100, 200, which isn't a big deal. We're able to update them. You can also put a `var` in front of line 3 if you were to accidentally redeclare the variable. If you do, it won't do anything. It will work as you'd expect, but it won't yell at you for creating the same variable name twice in the same scope because `var` variables can be **updated** or **redefined**.
 
-We also need to remember how `var variables are scoped. **Scoping** essentially means, "Where are these variables available to me?" In the case of var` variables, they're **function scope**, which means that they are only available inside the function that they are created in. However, if they are not declared in a function, then they are **globally scoped**, and they're available in the whole window.
+We also need to remember how `var` variables are scoped. **Scoping** essentially means, "Where are these variables available to me?" In the case of `var` variables, they're **function scope**, which means that they are only available inside the function that they are created in. However, if they are not declared in a function, then they are **globally scoped**, and they're available in the whole window.
 
-If I created a function and put my var width inside of it, and console logged the width, and then I were to run it? Is that going to work?
+If I created a function and put my `var` width inside of it, and console logged the `width`, and then I were to run it? Is that going to work?
 
 
 ```js
@@ -41,9 +41,9 @@ setWidth();
 
 ```
 
-Of course, it's going to work because this width is available inside of this function.
+Of course, it's going to work because this `width` is available inside of this function.
 
-But if I also tried to console log the width after I've set the width like this?
+But if I also tried to console log the `width` after I've set the `width` like this?
 
 
 ```js
@@ -56,9 +56,9 @@ console.log(width); // error, width is not defined
 
 ```
 
-It won't work. Why won't it work? Because **`width is only scoped to that function**. It is a local variable to our setWidth function. It is not available outside the confines. Think of the curly brackets as gates, or function jail, and our var` variables are in there.
+It won't work. Why won't it work? Because **`width` is only scoped to that function**. It is a local variable to our `setWidth` function. It is not available outside the confines. Think of the curly brackets as gates, or function jail, and our `var` variables are in there.
 
-That's important for us to know. If you do want to globally scope width, we need to declare it outside the function like so, and update it inside the function:
+That's important for us to know. If you do want to globally scope `width`, we need to declare it outside the function like so, and update it inside the function:
 
 
 ```js
@@ -74,7 +74,7 @@ console.log(width);
 
 Generally, it's probably not what you want to do. You want to keep your variables inside of your function. If you need something outside of a function, you want to return it and store that in a variable. That's something that we need to know about function scoping. But I'm going to show you a use case where function scoping sort of comes back and bites us.
 
-Let's say we have an age variable and we have an if statement. We want to create a number of dog years. If they are greater than 12, let's calculate their ages in dog years and show "You are (however many) dog years old" in the console if they're older than 12.
+Let's say we have an `age` variable and we have an `if` statement. We want to create a number of dog years. If they are greater than 12, let's calculate their ages in dog years and show "You are (however many) dog years old" in the console if they're older than 12.
 
 
 ```js
@@ -89,9 +89,9 @@ if(age > 12) {
 
 Just as an aside, you can see I'm using back ticks in this example, but I'm going to tell you all about this in the "Template Strings" section.
 
-The one thing that is a little bit strange here is that `var dogYears is just a temporary variable, and I just needed this real quick in order to calculate something and then stick it into a console.log or stick it into a string or whatever. If you go to your browser console and call dogYears, you'll see that it's leaked outside of the if statement and it is now a global variable that lives on window`, which isn't really what we want.
+The one thing that is a little bit strange here is that `var dogYears` is just a temporary variable, and I just needed this real quick in order to calculate something and then stick it into a `console.log` or stick it into a string or whatever. If you go to your browser console and call `dogYears`, you'll see that it's leaked outside of the `if` statement and it is now a global variable that lives on `window`, which isn't really what we want.
 
-Even though this was a temporary variable that I only needed inside of one if statement, because `var variables are **function scoped** and remember, there's no function here, it's going to be **globally scoped**. It's scoped to the entire window, which is a little bit of a pain here. That is one of the benefits to using let and const`. Instead of being scoped to the function, it is **block scoped**, which is something new.
+Even though this was a temporary variable that I only needed inside of one if statement, because `var` variables are **function scoped** and remember, there's no function here, it's going to be **globally scoped**. It's scoped to the entire `window`, which is a little bit of a pain here. That is one of the benefits to using `let` and `const`. Instead of being scoped to the function, it is **block scoped**, which is something new.
 
 What is a block? Here is a great example:
 
@@ -107,7 +107,7 @@ if(age > 12) {
 
 ```
 
-Any time that you see **{ curly brackets }**, that's a block. Functions are also blocks, `let and const` are still going to be scoped to a function, but if inside of that function or if inside of some other element that you have, **it will be scoped to the closest set of curly brackets**.
+Any time that you see **{ curly brackets }**, that's a block. Functions are also blocks, `let` and `const` are still going to be scoped to a function, but if inside of that function or if inside of some other element that you have, **it will be scoped to the closest set of curly brackets**.
 
 If I now take this dog years here and change it to `let`...
 
@@ -123,6 +123,6 @@ console.log(dogYears); // error because it's scoped only to the above block
 
 ```
 
-...and I refresh, everything works as we would want. However, if you call `dogYears in the browser console, it says, "Dog years is not defined." Why? Because I declared it as a **let variable**. It is only declared inside of a block scope, now, not a global scope like var`, a block scope, and that temporary variable has not leaked out of the block.
+...and I refresh, everything works as we would want. However, if you call `dogYears` in the browser console, it says, "Dog years is not defined." Why? Because I declared it as a **let variable**. It is only declared inside of a block scope, now, not a global scope like `var`, a block scope, and that temporary variable has not leaked out of the block.
 
 You can also use `const` and get the same results, which is what we will talk about in the <a href="https://es6.io">ES6.io</a> video.

--- a/src/posts/How to Sanitize Data with ES6 Template Strings/How to Sanitize Data with ES6 Template Strings.mdx
+++ b/src/posts/How to Sanitize Data with ES6 Template Strings/How to Sanitize Data with ES6 Template Strings.mdx
@@ -97,7 +97,7 @@ const bio = document.querySelector('.bio');
 bio.innerHTML = html;
 ```
 
-So we have a `reduce function, which takes in a function and what we start with, an arrow function, which we'll use the first iteration, prev, our current iteration, next, and i for index. So we're just going to return a string that tacks all of those things together. We've got prev. We've got the next. We've got values, which is i` or nothing.
+So we have a `reduce` function, which takes in a function and what we start with, an arrow function, which we'll use the first iteration, `prev`, our current iteration, `next`, and `i` for index. So we're just going to return a string that tacks all of those things together. We've got `prev`. We've got the `next`. We've got values, which is `i` or nothing.
 
 We still have, "you got hacked" because we're not finished yet.
 
@@ -118,7 +118,7 @@ const bio = document.querySelector('.bio');
 bio.innerHTML = html;
 ```
 
-But instead, what we can do is add a new `const called dirty, because our string is dirty because it still has it's onload`, or iFrames, or any of the other nasty stuff people are trying to do.
+But instead, what we can do is add a new `const` called `dirty`, because our string is dirty because it still has it's `onload`, or iFrames, or any of the other nasty stuff people are trying to do.
 
 Now we'll use our library that we loaded, and it's called with `DOMPurify.sanitize`. We'll sanitize the dirty HTML:
 

--- a/src/posts/Is var Dead What should I use/Is var Dead What should I use.mdx
+++ b/src/posts/Is var Dead What should I use/Is var Dead What should I use.mdx
@@ -9,9 +9,9 @@ date: 2016-09-07T11:39:24
 id: 3828
 ---
 
-We've learned about `let and const` — what they do, and how they're scoped. We also know when they can be reassigned and when they cannot, but there's a question: What Should I actually use?
+We've learned about `let` and `const` — what they do, and how they're scoped. We also know when they can be reassigned and when they cannot, but there's a question: What Should I actually use?
 
-That's a bit of a hot topic in the community right now, because some people prefer to still use `var. Some people are saying, "var is dead!" Some say, "Use let." while others always use const`.
+That's a bit of a hot topic in the community right now, because some people prefer to still use `var`. Some people are saying, "var is dead!" Some say, "Use let." while others always use `const`.
 
 `var` isn't dead - it still does what it always has done — it's <a href="http://wesbos.com/javascript-scoping/">function scoped</a> and <a href="http://wesbos.com/let-vs-const/">you can reassign or re-bind it</a>. You may very well continue to choose it. There isn't a <em>right</em> answer here, just opinions. Check them out and make your own decisions.
 
@@ -19,7 +19,7 @@ I'm just going to go over two of the leading opinions here. These are both done 
 
 <a href="https://mathiasbynens.be/notes/es6-const">This one, by Mathias Bynens, is how I do it</a>. He says that "`const` is not about immutability where you can change the properties."
 
-Later on in the article he talks about `let vs. const`...
+Later on in the article he talks about `let` vs. `const`...
 
 <blockquote>
   
@@ -33,7 +33,7 @@ Later on in the article he talks about `let vs. const`...
   
 </blockquote>
 
-Whenever you make a variable, assume it's `const.  Only use let if you need to update the value of the variable. You can use const` to keep it the same value.
+Whenever you make a variable, assume it's `const`. Only use let if you need to update the value of the variable. You can use `const` to keep it the same value.
 
 <a href="http://blog.getify.com/constantly-confusing-const/">Another popular opinion here is from Kyle Simpson</a>, and he also writes a whole bunch of awesome JavaScript books.
 
@@ -44,11 +44,11 @@ Whenever you make a variable, assume it's `const.  Only use let if you need to u
 
   * Use `let` for localized variables in smaller scopes.
 
-  * Refactor `let to const` only after some code has to be written, and you're reasonably sure that you've got a case where there shouldn't be variable reassignment.
+  * Refactor `let` to `const` only after some code has to be written, and you're reasonably sure that you've got a case where there shouldn't be variable reassignment.
 
   
 </blockquote>
 
-He says, basically, Use `var to share larger scopes so you can put them inside of your function, and use let in smaller scopes. If you realize later that you need to update a value, you'd have to go back and make it a let instead of a const. If you use let, it's easier to go back and refactor them to const`.
+He says, basically, Use `var` to share larger scopes so you can put them inside of your function, and use `let` in smaller scopes. If you realize later that you need to update a value, you'd have to go back and make it a `let` instead of a `const`. If you use `let`, it's easier to go back and refactor them to `const`.
 
-Both of those are very valid opinions. I'll let you make your own choice on that, but through <a href="https://es6.io">the ES6.io series</a>, I'll be using `const by default, let whenever I need to reassign a variable, and stay away from var` entirely.
+Both of those are very valid opinions. I'll let you make your own choice on that, but through <a href="https://es6.io">the ES6.io series</a>, I'll be using `const` by default, `let` whenever I need to reassign a variable, and stay away from `var` entirely.

--- a/src/posts/JavaScript Arrow Functions Introduction/JavaScript Arrow Functions Introduction.mdx
+++ b/src/posts/JavaScript Arrow Functions Introduction/JavaScript Arrow Functions Introduction.mdx
@@ -45,7 +45,7 @@ That makes sense to me, but this isn't an arrow function. Let's take a look at h
 
 <h3>Turn it into an Arrow Function</h3>
 
-The first thing you do with an arrow function is, you simply delete the keyword `function and add in what's called a fat arrow. It looks like this: =>`
+The first thing you do with an arrow function is, you simply delete the keyword `function` and add in what's called a fat arrow. It looks like this: `=>`
 
 
 ```js
@@ -59,7 +59,7 @@ console.log(fullNames2); // Wes Bos, Kait Bos, Lux Bos
 
 If you've come from other programming languages, you might have seen that before, but in JavaScript it's the first time we're seeing a fat arrow.
 
-It'll do exactly the same thing as `function. If you console.log` it, there should be no surprises there. We get the exact same thing.
+It'll do exactly the same thing as `function`. If you `console.log` it, there should be no surprises there. We get the exact same thing.
 
 <h3>Removing Parens With Single Params</h3>
 
@@ -83,7 +83,7 @@ What else could I do with this? I can use what's called an **implicit return**.
 
 Hold on — what's a <em>explicit</em> `return`?
 
-That's when you explicitly write `return for what you want to return`. But a lot of these callback functions that we write in JavaScript are just one-liners, where we <em>just return something immediately</em> in one line. We don't need a whole bunch of lines.
+That's when you explicitly write `return` for what you want to `return`. But a lot of these callback functions that we write in JavaScript are just one-liners, where we <em>just return something immediately</em> in one line. We don't need a whole bunch of lines.
 
 **So - if the only purpose of your arrow function is to return something, there is no need for the `return` keyword. **
 
@@ -127,7 +127,7 @@ console.log(fullNames5); // Cool Bos, Cool Bos, Cool Bos
 
 ```
 
-Another pattern you may see is developers using an underscore `_ in place of ()`:
+Another pattern you may see is developers using an underscore `_` in place of `()`:
 
 
 ```js
@@ -135,7 +135,7 @@ names.map(_ => `Cool Bos`);
 
 ```
 
-We call this a <em>throwaway variable</em> because we're actually creating a variable called `_ but not using it. It's important to note that the _` **does not have any significance at all**. I could use any variable name here, we just throw it away.
+We call this a <em>throwaway variable</em> because we're actually creating a variable called `_` but not using it. It's important to note that the `_` **does not have any significance at all**. I could use any variable name here, we just throw it away.
 
 
 ```js
@@ -146,7 +146,7 @@ names.map(do_yaget_the_point => `Cool Bos`);
 
 ```
 
-Personally I prefer to use `() => over _ =>` when there are no params but I'll let you make that decision on your own.
+Personally I prefer to use `() =>` over `_ =>` when there are no params but I'll let you make that decision on your own.
 
 <h3>Arrow Functions are Always Anonymous Functions</h3>
 

--- a/src/posts/JavaScript Arrow Functions and this scoping/JavaScript Arrow Functions and this scoping.mdx
+++ b/src/posts/JavaScript Arrow Functions and this scoping/JavaScript Arrow Functions and this scoping.mdx
@@ -15,7 +15,7 @@ What does that mean? Let's show an example as to when you might run into this. T
 
 http://codepen.io/wesbos/pen/KgpNjJ
 
-What I have here is I've got this `div with the class of box` right here.
+What I have here is I've got this `div` with the class of `box` right here.
 
 
 ```html
@@ -28,9 +28,9 @@ What I have here is I've got this `div with the class of box` right here.
 
 ```
 
-When you click that box what's going to happen is a two-stage animation. You click it, and it grows. Then it animates in the `h2, and the social` paragraph, from the left and from the right.
+When you click that box what's going to happen is a two-stage animation. You click it, and it grows. Then it animates in the `h2`, and the `social` paragraph, from the left and from the right.
 
-With the source files, you can try this out in your browser's element inspector. First add a class of `opening to the div`:
+With the source files, you can try this out in your browser's element inspector. First add a class of `opening` to the `div`:
 
 
 ```html
@@ -45,7 +45,7 @@ With the source files, you can try this out in your browser's element inspector.
 
 What that does it actually grows it.
 
-Then if you add a class of `open()` to it, that will bring in the text.
+Then if you add a class of `open` to it, that will bring in the text.
 
 
 ```html
@@ -58,15 +58,15 @@ Then if you add a class of `open()` to it, that will bring in the text.
 
 ```
 
-It's always on the `<div class="box">, adding opening, and then after a couple of seconds I have a class of open` being added to it.
+It's always on the `<div class="box">`, adding `opening`, and then after a couple of seconds I have a class of `open` being added to it.
 
 I've given you all of the CSS that comes along with it. Nothing too exciting here, and that's a whole another course together.
 
-Essentially the way it works is when it has a class of `opening I just change the width and the height. Then, when it has a class of open`, I bring all of the text in. Then I've got transitions on everything so it goes has some funky effects.
+Essentially the way it works is when it has a class of `opening` I just change the width and the height. Then, when it has a class of `open`, I bring all of the text in. Then I've got transitions on everything so it goes has some funky effects.
 
 If you open it in the browser and click it, though, you'll see that nothing works.
 
-We need to select that element. So in the `<script> tags, we're going to use const`, just because we won't want the reference to the box to change.
+We need to select that element. So in the `<script>` tags, we're going to use `const`, just because we won't want the reference to the box to change.
 
 
 ```js
@@ -88,7 +88,7 @@ box.addEventListener('click', function() {
 
 ```
 
-It logs `this as the same as box. The way you can think about this is you look at what got called addEventListener, and you look at the thing to the left of it, box. What's box? That's the div with the class of box` that we have.
+It logs `this` as the same as `box`. The way you can think about this is you look at what got called `addEventListener`, and you look at the thing to the left of it, `box`. What's `box`? That's the `div` with the class of `box` that we have.
 
 That's good. But, if you swap this out with an arrow function here, watch what happens:
 
@@ -101,13 +101,13 @@ box.addEventListener('click', () => {
 
 ```
 
-We get `Window. Why do we get Window` here?
+We get `Window`. Why do we get `Window` here?
 
 That's because when you use an arrow function, the value of `this` is **not rebound** inside of that function. It is just inherited form whatever the parent scope is.
 
 What's the parent scope of this? It's `Window`, as in the browser window.
 
-If you use your console here and type `this, you'll see that this is equal to Window`, because it's not being bound to anything. It ends up by the window.
+If you use your console here and type `this`, you'll see that `this` is equal to `Window`, because it's not being bound to anything. It ends up by the window.
 
 You don't just want to go willy-nilly using arrow functions everywhere, because it's just less to type. You need to know what the benefits and the drawbacks of them are. In this case I don't want an arrow function, because I need the keyword to reference the actual box that got clicked. That would be even more important if I had a whole bunch of them.
 
@@ -170,7 +170,7 @@ box.addEventListener('click', function() {
 
 ```
 
-If we run that, we see that `this.classList comes back as undefined. It's nothing. Why is there no classList` on the box?
+If we run that, we see that `this.classList` comes back as `undefined`. It's nothing. Why is there no `classList` on the box?
 
 Let's take another look, this time we'll just `console.log(this)` to get a little deeper:
 
@@ -189,11 +189,11 @@ box.addEventListener('click', function() {
 
 We'll see that it's targeting `Window`. Why's that?
 
-If `this inside the opening toggle function here was equal to box, why the heck is it not equal to box` for the open function?
+If `this` inside the opening toggle function here was equal to `box`, why the heck is it not equal to `box` for the open function?
 
-That's because we've entered a new function, and `this` inside the function has **not been bound** to anything, which means that, if it's not bound to anything, it's going to be equal to the window. That's a pain in the ass.
+That's because we've entered a new function, and `this` inside the function has **not been bound** to anything, which means that, if it's not bound to anything, it's going to be equal to the `window`. That's a pain in the ass.
 
-A lot of people would solve this by adding a `self variable and use it to trigger the class open` like this:
+A lot of people would solve this by adding a `self` variable and use it to trigger the class `open` like this:
 
 
 ```js
@@ -211,7 +211,7 @@ box.addEventListener('click', function() {
 
 That's works, but not the greatest, because we have this weird or some of you like to say `var that = this;` and etc.
 
-Fortunately, we don't need to do that anymore if I bring that back to this. What we need to do is just simply make it an arrow function:
+Fortunately, we don't need to do that anymore if I bring `that` back to `this`. What we need to do is just simply make it an arrow function:
 
 
 ```js
@@ -226,9 +226,9 @@ box.addEventListener('click', function() {
 
 ```
 
-Why? Because when you have an arrow function, **it does not change the value** of `this`. It inherits the value of this from the **parent**. We don't have to worry about the scope changing or anything like that.
+Why? Because when you have an arrow function, **it does not change the value** of `this`. It inherits the value of `this` from the **parent**. We don't have to worry about the scope changing or anything like that.
 
-We can just go ahead and keep working using this as if it was scoped to this actual function here, just great.
+We can just go ahead and keep working using `this` as if it was scoped to this actual function here, just great.
 
 
 ```js
@@ -249,7 +249,7 @@ So let's run that, and click it again and it closes. That's a little bit funky. 
 
 None of this has anything to do with arrow functions. If you're interested in seeing how I might figure this out, you can stay on with me.
 
-The problem with this right here is that when you toggle an `open, it adds a class of opening, then after 500 milliseconds it adds a class of open`. When you close it down, you want it to be the opposite.
+The problem with this right here is that when you toggle an `open`, it adds a class of `opening`, then after 500 milliseconds it adds a class of `open`. When you close it down, you want it to be the opposite.
 
 The way I would probably solve this is to first make two variables.
 
@@ -270,7 +270,7 @@ box.addEventListener('click', function() {
 
 I'm just using variables so we still have this problem.
 
-Let's add an `if` statement to switch our variables around. This is going to look forward into our destructuring exercise, but as little hot tip. If we want to switch two variables with ES6 you can simply put them in an array:
+Let's add an `if` statement to switch our variables around. This is going to look forward into our destructuring exercise, but as a little hot tip. If we want to switch two variables with ES6 you can simply put them in an array:
 
 
 ```js

--- a/src/posts/JavaScript Default Function Arguments/JavaScript Default Function Arguments.mdx
+++ b/src/posts/JavaScript Default Function Arguments/JavaScript Default Function Arguments.mdx
@@ -11,7 +11,7 @@ id: 3832
 
 Default function arguments in JavaScript are here. This is one of those features that's going to make your life much easier, and make your code much more readable and maintainable.
 
-Let's say we have a function called `calculateBill which is going to take in three things: the total cost of your meal, how much tax we need to pay, and then how much you would like to tip` your waiter:
+Let's say we have a function called `calculateBill` which is going to take in three things: the `total` cost of your meal, how much `tax` we need to pay, and then how much you would like to `tip` your waiter:
 
 
 ```js
@@ -21,7 +21,7 @@ function calculateBill(total, tax, tip) {
 
 ```
 
-From that, we can return the total amount of hte bill.
+From that, we can return the total amount of the bill.
 
 Then we'll make a new variable called `totalBill`, and we'll use our new function, to figure out how much all of that costs.
 
@@ -40,7 +40,7 @@ On a $100 meal, with 13% tax and a 15% tip, the console will tells us `128`, or 
 
 What happens if we want to automatically assume 13% tax rate, and we want to assume a 15% tip rate?
 
-What we could do is just pass in our $100 meal and get our result. If we omit `tax and tip — calculateBill(100) our function returns us NaN`, or "not a number". That's because we're trying to do math against things that aren't passed in.
+What we could do is just pass in our $100 meal and get our result. If we omit `tax` and `tip` — `calculateBill(100)` our function returns us `NaN`, or "not a number". That's because we're trying to do math against things that aren't passed in.
 
 
 ```js
@@ -54,7 +54,7 @@ console.log(totalBill);
 
 ```
 
-If you use `console.log to show the value of tax or tip, you'll see that they show up as undefined`.
+If you use `console.log` to show the value of `tax` or `tip`, you'll see that they show up as `undefined`.
 
 What we would normally do is we would add an `if` loop:
 
@@ -94,7 +94,7 @@ console.log(totalBill);
 
 I don't mind that, but it can be a little bit hard on your team to have to read it. If you've got four or five different arguments coming in, then you've got to do all this crazy code at the top.
 
-Another thing to note is the `|| trick will fallback to the default if you pass in 0, null, false` or any other falsy value. Not exactly what you want when you are trying to tip $0!
+Another thing to note is the `||` trick will fallback to the default if you pass in `0`, `null`, `false` or any other falsy value. Not exactly what you want when you are trying to tip $0!
 
 So let's just do without that entirely. What we can do now in ES6 is just simply set it when we define our function, and those things will be assumed.
 
@@ -130,7 +130,7 @@ console.log(totalBill);
 
 How do you leave a hole in here?
 
-Well, what does this essentially check for? It checks for tax being passed `undefined so you can just explicitly pass undefined`:
+Well, what does this essentially check for? It checks for tax being passed `undefined` so you can just explicitly pass `undefined`:
 
 
 ```js

--- a/src/posts/More Arrow Function Examples/More Arrow Function Examples.mdx
+++ b/src/posts/More Arrow Function Examples/More Arrow Function Examples.mdx
@@ -24,7 +24,7 @@ const winners = ['Hunter Gath', 'Singa Song', 'Imda Bos'];
 
 So Hunter Gath came in first, Singa Song came in second, and Imda Bos came in third.
 
-Ideally for me, I would have an object with `name, with the name of the racer, place` with the place that they came in, and we can use the race variable to say what they won. Something like this:
+Ideally for me, I would have an object with `name`, with the name of the racer, `place` with the place that they came in, and we can use the `race` variable to say what they won. Something like this:
 
 
 ```js
@@ -36,7 +36,7 @@ Ideally for me, I would have an object with `name, with the name of the racer, p
 
 ```
 
-How would we do that? Well, we can actually use `.map() again for that. By the way, map` is not the only function that arrow functions work with. Arrow functions work with anything, and they're particularly useful in these callback situations.
+How would we do that? Well, we can actually use `.map()` again for that. By the way, `map` is not the only function that arrow functions work with. Arrow functions work with anything, and they're particularly useful in these callback situations.
 
 
 ```js
@@ -44,13 +44,13 @@ const win = winners.map((winner, i) => {name: winner, race: race, place: i})
 
 ```
 
-We're going to loop over each winner and return an object for each of the winners here. Our function passes two arguments, the `winner string and i, for our index, and we're going to return our name, race, and place` that the person came in.
+We're going to loop over each winner and return an object for each of the winners here. Our function passes two arguments, the `winner` string and `i`, for our index, and we're going to return our `name`, `race`, and `place` that the person came in.
 
 <h3>Arrow Function Implicit Return an Object Literal</h3>
 
 That should work, where we've got this object here, but it doesn't work, it throws a syntax error: `Unexpected token :`
 
-What's wrong here? Well, earlier we told you that if you take the curly brackets off it's an implicit `return. How do you implicit return`curly brackets when you mean for it to be an **object literal**, not the actual function block?
+What's wrong here? Well, earlier we told you that if you take the curly brackets off it's an implicit `return`. How do you implicit `return` curly brackets when you mean for it to be an **object literal**, not the actual function block?
 
 What we can do is, you just put parentheses around the object literal so that the arrow function knows it's an object and <em>not</em> a a function block.
 
@@ -60,7 +60,7 @@ const win = winners.map((winner, i) => ({name: winner, race: race, place: i + 1}
 
 ```
 
-These parentheses show that you're actually going to return an object literal, and these curly brackets aren't for the actual function block. So `name is winner, race is the race variable we have, and place is going to be set to i + 1`, our index, plus one so that we aren't zero-based.
+These parentheses show that you're actually going to return an object literal, and these curly brackets aren't for the actual function block. So `name` is `winner`, `race` is the `race` variable we have, and `place` is going to be set to `i + 1`, our index, plus one so that we aren't zero-based.
 
 <h3>Viewing our Data</h3>
 
@@ -68,9 +68,9 @@ Now we'll take a look at our data.
 
 <img src="ss-2016-09-07-at-10.50.42-AM.png" alt="" />
 
-A little hot tip, you refresh. You can type `win in the console to see all your objects, but then you got to do all this work on opening them up. What you can actually do is use console.table(win)` and you get a sweet-looking table that will show you all the information.
+A little hot tip, you refresh. You can type `win` in the console to see all your objects, but then you got to do all this work on opening them up. What you can actually do is use `console.table(win)` and you get a sweet-looking table that will show you all the information.
 
-Then the other thing, we haven't learned about this yet, but `race: race in our object looks a little bit redundant. A new feature of ES6 is you can just use race,  which is the same thing as saying, race: race Just say the variable race and the property name race is all named race`. It's going to do it just for us.
+Then the other thing, we haven't learned about this yet, but `race: race` in our object looks a little bit redundant. A new feature of ES6 is you can just use `race`,  which is the same thing as saying, `race: race`. Just say the variable `race` and the property name `race` is all named `race`. It's going to do it just for us.
 
 
 ```js
@@ -98,7 +98,7 @@ const old = ages.filter(age => if(age > 60))...
 
 ```
 
-Since we can pass it a condition that goes to true or false, and filter will return if it's true and it won't return if it's false, we can just say, "Age is greater or equal to 60."
+Since we can pass it a condition that goes to `true` or `false`, and `filter` will return if it's `true` and it won't return if it's `false`, we can just say, "Age is greater or equal to 60."
 
 
 ```js
@@ -106,6 +106,6 @@ const old = ages.filter(age => age >= 60);
 
 ```
 
-That looks like a bit funky because you got an arrow and a greater than, but what that will do is, if the age is greater or equal to 60, it will return `true and thus be put into the old` array.
+That looks like a bit funky because you got an arrow and a greater than, but what that will do is, if the age is greater or equal to 60, it will return `true` and thus be put into the `old` array.
 
 That age is going to be put back into this new old array, and we can use `console.log(old)` to return our filtered array.

--- a/src/posts/Quick Tip -  Use let with for Loops in JavaScript/Quick Tip -  Use let with for Loops in JavaScript.mdx
+++ b/src/posts/Quick Tip -  Use let with for Loops in JavaScript/Quick Tip -  Use let with for Loops in JavaScript.mdx
@@ -9,7 +9,7 @@ date: 2016-08-31T11:59:54
 id: 3814
 ---
 
-The other problem using `let and const will fix is with our for` loop.
+The other problem using `let` and `const` will fix is with our `for` loop.
 
 This is something that you probably have all run into with your regular `for` loop, like one that will count from zero to nine:
 
@@ -23,7 +23,7 @@ for(var i = 0; i < 10; i++) {
 
 Problems that arise here are two things:
 
-**First** of all, if I type `i into the console, it returns 10`. We have this global variable that has leaked into the window, or into a parent scope, which is not something we necessarily want. It's just a placeholder value that we need to work inside of this loop.
+**First** of all, if I type `i` into the console, it returns `10`. We have this global variable that has leaked into the window, or into a parent scope, which is not something we necessarily want. It's just a placeholder value that we need to work inside of this loop.
 
 **Second** of all, maybe you had something that's going to run after some bit of time, an AJAX request, or, for this case, I going to mark it up with a `setTimeout()` and that function is going to run after one second:
 
@@ -38,15 +38,15 @@ for(var i = 0; i < 10; i++) {
 
 ```
 
-If we run this, all of them are 10. The reason that we have that is because, `console.log(i)  will run immediately and reference whatever i is. That runs immediately at console.log` itself.
+If we run this, all of them are 10. The reason that we have that is because, `console.log(i)` will run immediately and reference whatever `i` is. That runs immediately at `console.log` itself.
 
 However, after one second, this entire loop has already gone through every iteration that it needs to and the variable `i` here is being overwritten every single time.
 
-The problem with that is that by the time the first `setTimeout() runs, i` is already at 10, and we don't have any way to reference it.
+The problem with that is that by the time the first `setTimeout()` runs, `i` is already at 10, and we don't have any way to reference it.
 
 If you had an AJAX request where you are looping through a few of them, there isn't any way without an IFFE to reference what the `i` variable was when it ran, not what it currently is after the loop.
 
-One quick way we can fix that is if we just change `var to let`:
+One quick way we can fix that is if we just change `var` to `let`:
 
 
 ```js
@@ -59,6 +59,6 @@ for(let i = 0; i < 10; i++) {
 
 ```
 
-What do we know about `let? It's block-scoped. We have curly brackets in the for` loop. If you run it now, after a second we'll log zero through nine. We're not getting 10, 10 times. We getting it as it was declared each and every time.
+What do we know about `let`? It's block-scoped. We have curly brackets in the `for` loop. If you run it now, after a second we'll log zero through nine. We're not getting 10, 10 times. We getting it as it was declared each and every time.
 
-As a note, you couldn't use a `const for this because it needs to overwrite itself, and you can't assign the same variable twice. When we use let, it's going to scope i` to our curly brackets.
+As a note, you couldn't use a `const` for this because it needs to overwrite itself, and you can't assign the same variable twice. When we use `let`, it's going to scope `i` to our curly brackets.

--- a/src/posts/Rename  Destructure Variables in ES6/Rename  Destructure Variables in ES6.mdx
+++ b/src/posts/Rename  Destructure Variables in ES6/Rename  Destructure Variables in ES6.mdx
@@ -29,13 +29,13 @@ const wes = {
 };
 ```
 
-For example here, I already used twitter as a variable. I can't use it again, but I'm stuck, because this object gives me twitter as a key and this object gives me twitter as a key. What you can do is you can rename them as you destructure them.
+For example here, I already used `twitter` as a variable. I can't use it again, but I'm stuck, because this object gives me `twitter` as a key and this object gives me twitter as a key. What you can do is you can rename them as you destructure them.
 
-So - I want the `twitter property, but I want to call it tweet. I want the facebook property, but I want to call it fb`.
+So - I want the `twitter` property, but I want to call it `tweet`. I want the `facebook` property, but I want to call it `fb`.
 
 
 ```js
 const { twitter: tweet, facebook: fb } = wes.links.social;
 ```
 
-The above code will pull the `wes.links.social.twitter into a variable called tweet and similarly for facebook`.
+The above code will pull the `wes.links.social.twitter` into a variable called `tweet` and similarly for `facebook`.

--- a/src/posts/Setting Default Values with JavaScripts Destructuring/Setting Default Values with JavaScripts Destructuring.mdx
+++ b/src/posts/Setting Default Values with JavaScripts Destructuring/Setting Default Values with JavaScripts Destructuring.mdx
@@ -51,7 +51,7 @@ const speed = mySpeed || 760;
 console.log(speed); // 760!
 ```
 
-Why? Because ES6 destructuring default values only kick in if the value is `undefined`, `null`, `false` and `0` are all still values!
+Why? Because ES6 destructuring default values only kick in if the value is `undefined`. `null`, `false` and `0` are all still values!
 
 
 ```js
@@ -96,9 +96,9 @@ Woah - let's step through that one!
 
 * First we create a new const var called `middleName`.
 
-* Next we look for `person.middle. If there was a person.middle property, it would be put into the middleName` variable.
+* Next we look for `person.middle`. If there was a `person.middle` property, it would be put into the `middleName` variable.
 
-* There isn't a `middle property on our person object, so we fall back to the default of Super Rad`. 
+* There isn't a `middle` property on our `person` object, so we fall back to the default of `Super Rad`. 
 
 
 Cool! Make sure to check out <a href="https://ES6.io">ES6.io</a> for more like this!

--- a/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
+++ b/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
@@ -65,7 +65,7 @@ First, we get an array of all the string pieces:
 After the array of all the 
 , the subsequent arguments will be the values that are being interpolated.
 
-In this case, we're passing `name and age`.
+In this case, we're passing `name` and `age`.
 
 
 ```js
@@ -119,7 +119,7 @@ console.log(sentence)
 
 I'm using `let` here. Why? Because we're going to be appending more strings on to this actual string. If I used `const`, I wouldn't be able to tack onto it.
 
-Then, we want to loop over this first strings array here, tack on `My dog's name is`, and then the first value, and he is and the second value, and then `years old` and then third value, but in this case, we don't have a third value.
+Then, we want to loop over this first strings array here, tack on `My dog's name is`, and then the first value, `and he is` and the second value, and then `years old` and then third value, but in this case, we don't have a third value.
 
 You can use whatever loop or logic you prefer inside of this function. You could even use a `map` and then join it together. I'm going to use `forEach` in my example:
 
@@ -143,9 +143,9 @@ That's going to say, "Give me the first value from the strings and the first val
 
 We're going to hit a little bit of an error here. If we `return str`, the string that we've been tacking things onto, we should now see `"My dog's name is Snickers and he is 100 years oldundefined."`
 
-First of all, remember, that's because the `strings` array is always going to be one larger than the values array. When we hit that last one, it's only going to be a string and there's going to be no value to tack on the end. You could check if values of [i] is `undefined` and, if it is, then don't put it on.
+First of all, remember, that's because the `strings` array is always going to be one larger than the values array. When we hit that last one, it's only going to be a string and there's going to be no value to tack on the end. You could check if values of `[i]` is `undefined` and, if it is, then don't put it on.
 
-A little trick you can do here, is you can use your values of I or just a blank string:
+A little trick you can do here, is you can use your values of `i` or just a blank string:
 
 
 ```js

--- a/src/posts/Temporal Dead Zone/Temporal Dead Zone .mdx
+++ b/src/posts/Temporal Dead Zone/Temporal Dead Zone .mdx
@@ -20,7 +20,7 @@ console.log(pizza);
 
 ```
 
-What happens when you try and log `pizza to the console after it's been created? You'll see that we actually get to see 'Deep Dish 🍕🍕🍕'`.
+What happens when you try and log `pizza` to the console after it's been created? You'll see that we actually get to see `'Deep Dish 🍕🍕🍕'`.
 
 No big issue there.
 
@@ -49,10 +49,10 @@ We get `undefined`.  Why?
 
 Because with `var` variables, you can only access them as they are defined. Before they are defined, you cannot access the actual value of them, but **you can access the fact that the variable has been created before**.
 
-However, if I change that to `const or let, you'll now see that pizza` is not defined at all. That's an actual error, and that will **break your code**.
+However, if I change that to `const` or `let`, you'll now see that `pizza` is not defined at all. That's an actual error, and that will **break your code**.
 
 That is called the **temporal dead zone**, where you cannot access a variable before it is defined.
 
-They mean that this is the temporal dead zone between `console.log and a let or const` variable, because you cannot access those kinds of variables before they're created.
+They mean that this is the temporal dead zone between `console.log` and a `let` or `const` variable, because you cannot access those kinds of variables before they're created.
 
 That's all you need to know. Put that in your back pocket, because you'll need it someday!

--- a/src/posts/When Not to use an Arrow Function/When Not to use an Arrow Function.mdx
+++ b/src/posts/When Not to use an Arrow Function/When Not to use an Arrow Function.mdx
@@ -41,7 +41,7 @@ button.addEventListener('click', () => {
 
 But if we click it, we get an error in the console: `TypeError, cannot read property 'toggle' of undefined`
 
-What does that mean? Well, if we remember from earlier, it's the browser's `window attribute, right? We can use console.log` to confirm it:
+What does that mean? Well, if we remember from earlier, it's the browser's `window` attribute, right? We can use `console.log` to confirm it:
 
 
 ```js
@@ -53,7 +53,7 @@ button.addEventListener('click', () => {
 
 ```
 
-Remember: we talked about that if you use an arrow function, the keyword `this is not bound to that element. If we use a regular function, the keyword this` will be bound to the element we clicked!
+Remember: we talked about that if you use an arrow function, the keyword `this` is not bound to that element. If we use a regular function, the keyword `this` will be bound to the element we clicked!
 
 
 ```js
@@ -82,13 +82,13 @@ const person = {
 
 ```
 
-We have our method called `score, and whenever we call person.score, it should add one to our points`, which is currently 23.
+We have our method called `score`, and whenever we call `person.score`, it should add one to our `points`, which is currently 23.
 
 If we run `person.score();` a few times, we should be at 26 or something.
 
-But if I call `person, points` is still at 23. Why?
+But if I call `person`, `points` is still at 23. Why?
 
-Because it's trying to add points to the window! Remember, when using an arrow function `this` is not bound to anything and it just inherits it from the parent scope which in this case is the window.
+Because it's trying to add points to the `window`! Remember, when using an arrow function `this` is not bound to anything and it just inherits it from the parent scope which in this case is the `window`.
 
 So let's do the same thing with an OG function:
 
@@ -122,9 +122,9 @@ class Car {
 
 Here, I've got a `class`. We haven't learned about classes yet, but just know that this is a way for us to make new cars.
 
-I have a `class constructor where, when you call new Car we pass it the type of Car, as well as the colour of the Car`.
+I have a `class` constructor where, when you call new `Car` we pass it the type of `Car`, as well as the colour of the `Car`.
 
-I can say `beemer is a BMW that is blue, and the subie is a Subaru that is white`:
+I can say `beemer` is a `BMW` that is `blue`, and the `subie` is a `Subaru` that is `white`:
 
 
 ```js
@@ -133,7 +133,7 @@ const subie = new Car('Subaru', 'white');
 
 ```
 
-Let's go ahead and look at them by calling them in the console, you'll see that `subie comes back as Car {make: "Subaru", colour: "white"}, and beemer will come back as Car {make: "BMW", colour: "blue"}`, which is what we'd expect.
+Let's go ahead and look at them by calling them in the console, you'll see that `subie` comes back as `Car {make: "Subaru", colour: "white"}`, and `beemer` will come back as `Car {make: "BMW", colour: "blue"}`, which is what we'd expect.
 
 Now, after the fact, I added on this prototype method:
 
@@ -145,13 +145,13 @@ Car.prototype.summarize = () => {
 
 ```
 
-...and what that allows us to do is that, even after these things have been created, we can add methods onto all of them. So our `Car.prototype.summarize method is set, so let's type into the console: subie.summarize`.
+...and what that allows us to do is that, even after these things have been created, we can add methods onto all of them. So our `Car.prototype.summarize` method is set, so let's type into the console: `subie.summarize`.
 
-If you're using Chrome's console, you'll see that it auto-completes the method, because it's available to you. Even though we added it after we created the `Car, because I added it to the prototype`, it's available in every object that has been created from there.
+If you're using Chrome's console, you'll see that it auto-completes the method, because it's available to you. Even though we added it after we created the `Car`, because I added it to the `prototype`, it's available in every object that has been created from there.
 
-What this `prototype does is it returns this.make which is the make that we passed in, and this.color` in a sentence.
+What this `prototype` does is it returns `this.make` which is the `make` that we passed in, and `this.color` in a sentence.
 
-However, with our example, `this.car is undefined and the colour is undefined`. Why is that?
+However, with our example, `this.car` is `undefined` and the `colour` is `undefined`. Why is that?
 
 It's because we try to be cool. We try to be a bit of a hot shot here by using an arrow function. Again, why don't we use an arrow function here? Because we explicitly need the keyword `this` so you have to use a regular function:
 
@@ -163,7 +163,7 @@ Car.prototype.summarize = function() {
 
 ```
 
-Now, if we call `subie.summarize, it says it's a white Subaru, and beemer.summarize`, we get BMW in blue.
+Now, if we call `subie.summarize`, it says it's a white Subaru, and `beemer.summarize`, we get BMW in blue.
 
 Again, you must use a regular function for that.
 
@@ -183,15 +183,15 @@ const orderChildren = () => {
 
 ```
 
-It doesn't have to do with the keyword "this," but we don't have access to the `arguments` object when you use an arrow function.
+It doesn't have to do with the keyword "`this`," but we don't have access to the `arguments` object when you use an arrow function.
 
 This is helpful for when you want to run a function like `orderChildren` here, which can take unlimited arguments.
 
 It might take one, it might take 100. It's going to just say "This child was born #1", or whichever.
 
-For an example, let's type into the console `orderChildren('jill', 'wes', 'jenna'), which passes in jill as our first argument, wes, as our second, and jenna as our third. When you run it, you'll get an error: ReferenceError, arguments is not defined`.
+For an example, let's type into the console `orderChildren('jill', 'wes', 'jenna')`, which passes in `jill` as our first argument, `wes`, as our second, and `jenna` as our third. When you run it, you'll get an error: `ReferenceError, arguments is not defined`.
 
-this is because `arguments is a keyword that we have in our orderChildren that's going to give us an Array` or array-ish value of everything that was passed in.
+this is because `arguments` is a keyword that we have in our `orderChildren` that's going to give us an `Array` or array-ish value of everything that was passed in.
 
 However, you do not get the `arguments` object if you use an arrow function. When you use a regular function, which is going to give us the actual content that we need.
 
@@ -209,4 +209,4 @@ const orderChildren = function() {
 
 **Note:** Another fix for this is to use a `...rest` param to collect all the arguments into an array. We will learn all about that in the rest videos and blog posts!
 
-Again, to go through all those really quickly. Make sure that you aren't just using arrow functions willy-nilly. In general, if you do not need the `arguments object or you do not need this`, or you know that you will not need it in the future, then you can feel free to go ahead and use an arrow function on everything else.
+Again, to go through all those really quickly. Make sure that you aren't just using arrow functions willy-nilly. In general, if you do not need the `arguments` object or you do not need `this`, or you know that you will not need it in the future, then you can feel free to go ahead and use an arrow function on everything else.


### PR DESCRIPTION
In some of the ES6 posts the inline code blocks include the surrounding text between code blocks. I tidied up the backticks in the MDX to only wrap the code.

For example, before:
![code-blocks-1](https://user-images.githubusercontent.com/28233682/95511098-e2dc9b00-09ae-11eb-97e2-81be5b1d7c54.PNG)

And after:
![code-blocks-2](https://user-images.githubusercontent.com/28233682/95511139-f2f47a80-09ae-11eb-92a0-4a7755db00bd.PNG)
