### PR TITLE
#59 display nav loader when on slow connections

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -137,5 +137,12 @@ module.exports = {
     // },
     // `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-plugin-nprogress`,
+      options: {
+        color: '#ffc600',
+        showSpinner: false,
+      },
+    },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10090,9 +10090,9 @@
       }
     },
     "gatsby-plugin-nprogress": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-nprogress/-/gatsby-plugin-nprogress-2.3.11.tgz",
-      "integrity": "sha512-eUGuHB2MrSb4fV3W2yZoenPN5smOqWiaVUZe/GLUgOIl/WLhEp16qTfytTCyASNBspOXuCduSVcpto2fD/VVTg==",
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-nprogress/-/gatsby-plugin-nprogress-2.3.13.tgz",
+      "integrity": "sha512-5B6IZJpAIS5DyUbjACVeZkc2u0jgjq/lonoqaLRnMQMFdGDNNaFFR495vZbGD2dB0bQkqp9iCXbWtle/0sD11Q==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "nprogress": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gatsby-plugin-layout": "^1.3.11",
     "gatsby-plugin-manifest": "^2.4.31",
     "gatsby-plugin-mdx": "^1.2.41",
-    "gatsby-plugin-nprogress": "^2.3.11",
+    "gatsby-plugin-nprogress": "^2.3.13",
     "gatsby-plugin-offline": "^3.2.28",
     "gatsby-plugin-prettier-build": "^0.4.3",
     "gatsby-plugin-react-helmet": "^3.3.11",


### PR DESCRIPTION
Add [gatsby-plugin-nprogress](https://www.gatsbyjs.org/packages/gatsby-plugin-nprogress/)

How to test:
- Run `npm i`
- Then `npm run dev`
- Open localhost and the inspector for your browser
- Go to the Network tab and change your connection speed to “Slow 3G” (Chrome)
- Use any navigation button except “Podcast” and the NProgress bar should show up at the top of the site.

Looks like it can be a bit finicky with how Gatsby is loading content but it still looks to be working as intended. 
