### PR TITLE
Fix gatsby-plugin-prettier-build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,15 +13,14 @@ module.exports = {
     `gatsby-plugin-image`,
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-remove-trailing-slashes`,
-    // taking this off for a bit because its broken or choking on somthing...
-    // {
-    //   resolve: `gatsby-plugin-prettier-build`,
-    //   options: {
-    //     types: ['html'],
-    //     concurrency: 20,
-    //     verbose: true,
-    //   },
-    // },
+    {
+      resolve: `gatsby-plugin-prettier-build`,
+      options: {
+        types: ['html'],
+        concurrency: 20,
+        verbose: true,
+      },
+    },
     {
       // This tells us where the plugin lives
       // this one is in our node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "gatsby-plugin-mdx": "^1.10.0",
         "gatsby-plugin-nprogress": "^2.10.0",
         "gatsby-plugin-offline": "^3.10.0",
-        "gatsby-plugin-prettier-build": "^0.4.3",
+        "gatsby-plugin-prettier-build": "^0.4.4",
         "gatsby-plugin-react-helmet": "^3.10.0",
         "gatsby-plugin-remove-trailing-slashes": "^2.10.0",
         "gatsby-plugin-sharp": "^2.14.1",
@@ -6164,7 +6164,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -11793,9 +11792,9 @@
       }
     },
     "node_modules/gatsby-plugin-prettier-build": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-prettier-build/-/gatsby-plugin-prettier-build-0.4.3.tgz",
-      "integrity": "sha512-lrAHyDlGFcSnttLD8Niu32o3rqQbnUA8wJXKMzOL8TX5HmivoQx1nuANzFPL+tA4FXMwezxMI4kdyntiwNEiJw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-prettier-build/-/gatsby-plugin-prettier-build-0.4.4.tgz",
+      "integrity": "sha512-YYuKYovXZC98oMfiEdY7B1zVOwLfs2DB73Azz+U/MBHyFr6Bcm3UXBU4bZ/DJ/nimbUfwVpn/t9ckUUPPyBcjg==",
       "dependencies": {
         "p-limit": "^2.3.0",
         "prettier": "^2.0.4",
@@ -11965,7 +11964,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -13248,7 +13246,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -17776,9 +17773,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -25789,7 +25783,6 @@
         "async-cache": "^1.1.0",
         "bl": "^4.0.0",
         "fd": "~0.0.2",
-        "graceful-fs": "^4.2.3",
         "mime": "^2.4.4",
         "negotiator": "~0.6.2"
       },
@@ -28598,10 +28591,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -28679,7 +28670,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -29127,7 +29117,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -41081,9 +41070,9 @@
       }
     },
     "gatsby-plugin-prettier-build": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-prettier-build/-/gatsby-plugin-prettier-build-0.4.3.tgz",
-      "integrity": "sha512-lrAHyDlGFcSnttLD8Niu32o3rqQbnUA8wJXKMzOL8TX5HmivoQx1nuANzFPL+tA4FXMwezxMI4kdyntiwNEiJw==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-prettier-build/-/gatsby-plugin-prettier-build-0.4.4.tgz",
+      "integrity": "sha512-YYuKYovXZC98oMfiEdY7B1zVOwLfs2DB73Azz+U/MBHyFr6Bcm3UXBU4bZ/DJ/nimbUfwVpn/t9ckUUPPyBcjg==",
       "requires": {
         "p-limit": "^2.3.0",
         "prettier": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gatsby-plugin-mdx": "^1.10.0",
     "gatsby-plugin-nprogress": "^2.10.0",
     "gatsby-plugin-offline": "^3.10.0",
-    "gatsby-plugin-prettier-build": "^0.4.3",
+    "gatsby-plugin-prettier-build": "^0.4.4",
     "gatsby-plugin-react-helmet": "^3.10.0",
     "gatsby-plugin-remove-trailing-slashes": "^2.10.0",
     "gatsby-plugin-sharp": "^2.14.1",


### PR DESCRIPTION
yo :wave:

I noticed you disabled the [`gatsby-plugin-prettier-build`](https://github.com/jmsv/gatsby-plugin-prettier-build) plugin because it was failing 😱

Turns out this was because some files in your Gatsby build output seems to have syntax errors, e.g. the `/wordpress-calypso-react` page:

![problem](https://user-images.githubusercontent.com/14852491/113625937-74288380-9659-11eb-9e17-60a56f5b1a09.png)

The plugin wasn't catching errors when trying to run the prettier format on version `0.4.3`

I've pushed [a fix](https://github.com/jmsv/gatsby-plugin-prettier-build/commit/7564710de7a04e0eefeb32de9123c3d3882aa6cf) to the plugin: [`0.4.4`](https://www.npmjs.com/package/gatsby-plugin-prettier-build/v/0.4.4). This now catches errors when trying to prettify a file, and logs to the console accordingly:

![solution](https://user-images.githubusercontent.com/14852491/113625391-cae18d80-9658-11eb-8e51-eba3ec47162f.png)

This PR bumps the package version and re-enables the plugin - hopefully it works!

P.S. I got one of the pink JS tees and it's awesome 😍  thanks