### PR TITLE
Update Setting Default Values with JavaScripts Destructuring.mdx

### DIFF
--- a/src/posts/Setting Default Values with JavaScripts Destructuring/Setting Default Values with JavaScripts Destructuring.mdx
+++ b/src/posts/Setting Default Values with JavaScripts Destructuring/Setting Default Values with JavaScripts Destructuring.mdx
@@ -51,7 +51,7 @@ const speed = mySpeed || 760;
 console.log(speed); // 760!
 ```
 
-Why? Because ES6 destructuring default values only kick in if the value is `undefined`, `null`, `false` and `0` are all still values!
+Why? Because ES6 destructuring default values only kick in if the value is `undefined`; `null`, `false` and `0` are all still values!
 
 
 ```js


### PR DESCRIPTION
Changed comma to semicolon in line 54 to accentuate that 'undefined' is part of the initial sentence. The `null`, `false` and `0` is part of "the punchline".

Sorry for interfering :-), I just had some Sunday time to sit and learn from courses and came across the not so common editing invitation.