### PR TITLE
➡️ Arrow function with single parameter

### DIFF
--- a/src/javascript/02-functions/15-different-ways-to-declare-functions/15-different-ways-to-declare-functions.mdx
+++ b/src/javascript/02-functions/15-different-ways-to-declare-functions/15-different-ways-to-declare-functions.mdx
@@ -326,7 +326,7 @@ _To recap: what we did there is we removed the function block, modified the code
 Finally, and this is more of a stylistic choice, if there is only ever one parameter for your function, you can actually get rid of the parenthesis around the parameter as well, like so👇
 
 ```js
-const inchToCM = (inches) => inches * 2.54;
+const inchToCM = inches => inches * 2.54;
 ```
 
 If there is only one parameter in your arrow function, you can remove them no problem. It is still a valid arrow function.


### PR DESCRIPTION
In the sample code for removing the parenthesis around a single parameter in an arrow function, the parenthesis had not actually been removed. This removes it 😃 