### PR TITLE
Missing heading?

### DIFF
--- a/src/javascript/03-the-tricky-bits/17-scope/17-scope.mdx
+++ b/src/javascript/03-the-tricky-bits/17-scope/17-scope.mdx
@@ -106,7 +106,7 @@ Because anything that is in the global scope is attached to the window object wi
 
 Using global scope is almost never a good idea, but before we learn why that is, we need to learn about how different parts of scope work.
 
-#ß# Function Scope
+## Function Scoping
 
 Let's get rid of the `<script>sayHi();</script>` code in `scope.html`.
 


### PR DESCRIPTION
Based on the structure of the article, it seems this should be a heading, and `#ß#` looks like an encoding error or a typo?