### PR TITLE
Update 15-different-ways-to-declare-functions.mdx

### DIFF
--- a/src/javascript/02-functions/15-different-ways-to-declare-functions/15-different-ways-to-declare-functions.mdx
+++ b/src/javascript/02-functions/15-different-ways-to-declare-functions/15-different-ways-to-declare-functions.mdx
@@ -310,7 +310,7 @@ Your code should look like the above 👆
 
 What we did there is:
 
-- we made an arrow function `inchToCM` which takes in one argument, `inches`
+- we made an arrow function `inchToCM` which takes in one parameter, `inches`
 - modified the function to implicitly return the value.
 
 The way we can tell this is an implicit return is that:


### PR DESCRIPTION
Should be parameter instead of argument,
Because previous sections of the course mentioned passing variables to the function always considered as "Parameter" and value considered as "Argument"