### PR TITLE
Update junocollege alumni for hire URL on contact page

### DIFF
--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -14,7 +14,7 @@ export default function ContactPage({ path }) {
       <p>
         <strong>If you want me to work for you</strong>, I am not accepting any
         client work at the moment, but I'd recommend you{' '}
-        <a href="https://junocollege.com/alumni/freelancers">
+        <a href="https://junocollege.com/alumni/available-for-hire">
           hire a Juno College freelancer
         </a>{' '}
         - they are great!


### PR DESCRIPTION
Noticed that the URL for the Juno College freelancers contact was shooting to a 404 page:
<img width="1069" alt="Screen Shot 2021-08-08 at 8 20 27 PM" src="https://user-images.githubusercontent.com/15256554/128652148-666091b3-cc6d-4287-ac39-b661ca2f1fe3.png">

Updated to the correct link:
<img width="946" alt="Screen Shot 2021-08-08 at 8 23 59 PM" src="https://user-images.githubusercontent.com/15256554/128652178-076ceaae-4bd4-4644-a966-edbdb7d305eb.png">