### PR TITLE
Correct backtick

### DIFF
--- a/src/javascript/01-the-basics/07-types-strings/07-types-strings.mdx
+++ b/src/javascript/01-the-basics/07-types-strings/07-types-strings.mdx
@@ -254,7 +254,7 @@ The `${}` syntax can only ever be used in backticks. It is the easiest way to po
 Almost anything can go between the curly brackets `{}` in that syntax. For example, you can do math. 👇
 
 ```js
-const hello = `hello my name is ${name}. Nice to meet you. I am ${1 + 100} years old';
+const hello = `hello my name is ${name}. Nice to meet you. I am ${1 + 100} years old`;
 ```
 
 JavaScript will run whatever is inside of the curly brackets in that syntax (whether it is a variable or an actual statement) and it will return the value that's inside of it.


### PR DESCRIPTION
It was a single quote when it should be a backtick.