### PR TITLE
Update 47-array-cardio-instance-methods.mdx

### DIFF
--- a/src/javascript/08-data-types/47-array-cardio-instance-methods/47-array-cardio-instance-methods.mdx
+++ b/src/javascript/08-data-types/47-array-cardio-instance-methods/47-array-cardio-instance-methods.mdx
@@ -245,14 +245,14 @@ const toppingsCopy2 = [...toppings];
 
 Wes likes using spreads a lot. It's a bit weird at first because the ... syntax might be a bit funky to you but Wes believes that once you understand what's actually going on there and how spreads work, then you are in good shape.
 
-The next exercise is to take out items 3 for 5 of the new toppings array with `splice()`.
+The next exercise is to take out items 3 to 5 of the new toppings array with `splice()`.
 
 ```js
-toppingsCopy.splice(3,5);
+toppingsCopy.splice(3,3);
 console.log(toppingsCopy);
 ```
 
-As you can see, there are now only 6 items rather than 11 in the array.
+As you can see, there are now only 8 items rather than 11 in the array.
 
 ![browser console showing toppingsCopy with splice method, starting at index 3, and taking out 5 elements](./570.png)
 


### PR DESCRIPTION
According to the original file, the exercise meant to take out items 3 to 5 with splice(). We only want to remove 3 items (3, 4 and 5), not 5.
Therefore, it should be newToppings.splice(3, 3). The first argument is where it starts and the second argument is the number of items we want to remove.