### PR TITLE
Update selection color to match the Cobalt2 theme.

### DIFF
--- a/src/components/mdxComponents/pre.js
+++ b/src/components/mdxComponents/pre.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components'
 
 const Pre = styled.pre`
+  *::selection {
+    background: #0050a4;
+  }
 `;
 
 export default Pre;


### PR DESCRIPTION
Fixes issue #76 

Updated the selection color for all of the Pre components to match the highlight color of Cobalt2.

I tested this on Chrome, Firefox, and Edge:
![image](https://user-images.githubusercontent.com/50255197/136015209-73f7cf8c-3382-4a8c-84f7-12235fecbcc0.png)
