### PR TITLE
Fix typo: "all the , the"

### DIFF
--- a/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
+++ b/src/posts/Tagged Template Literals/Tagged Template Literals.mdx
@@ -62,8 +62,7 @@ First, we get an array of all the string pieces:
 
 
 
-After the array of all the 
-, the subsequent arguments will be the values that are being interpolated.
+After this array, the subsequent arguments will be the values that are being interpolated.
 
 In this case, we're passing `name and age`.
 


### PR DESCRIPTION
"After the array of all the , the subsequent..." -> "After this array, the subsequent..."
Using "this array" to avoid repeating "array of all the", which is in the previous sentence.