### PR TITLE
Fixed Overflow Issue on JavaScript Pages and Blog

### DIFF
--- a/src/assets/styles/LayoutStyles.js
+++ b/src/assets/styles/LayoutStyles.js
@@ -5,7 +5,7 @@ const LayoutStyles = styled.div`
   min-height: calc(100vh - 40px);
   display: grid;
   grid-template-rows: auto 1fr auto;
-  @media (max-width: 400px) {
+  @media (max-width: 800px) {
     display: block;
   }
   &.welcome {

--- a/src/components/styles/JavaScriptNotesStyles.js
+++ b/src/components/styles/JavaScriptNotesStyles.js
@@ -8,9 +8,14 @@ const JavaScriptNotesStyles = styled.div`
     grid-template-columns: 25% 1fr;
   }
   @media (max-width: 800px) {
+    display: block;
     grid-template-columns: 1fr;
     aside {
       display: none;
+    }
+    code, 
+    h2 {
+      overflow-wrap: break-word;
     }
   }
   /* Overriding the build in styles, it's too large but I want to keep the 1500px for blog posts. So stupid it just might work */


### PR DESCRIPTION
Fixes #77, Fixes #179, Fixes #176

## Cause of Issue

The overflow issues were caused by grid being applied to the LayoutStyles container as well as the JavaScriptNotesStyles container. I resolved this by changing these to display: grid for mobile breakpoints below 800px instead of 400px.

The other overflow issues were caused by H2s and inline code blocks that were very long and didn't have any spaces in the name (see screenshots below)

## Verify Issue is Resolved

To verify the issue was resolved after I made these changes, I loaded every Javascript Notes & References page on mobile.

I also verified that removing the display: grid from the LayoutStyles container did not impact the Twitter feed at the bottom of the pages.

## Screenshots
### Inline Code Block
**Before**
![inline code block](https://user-images.githubusercontent.com/50255197/137396488-08b7a6b5-462e-4284-b8fe-2e97b8dc25b8.png)
**After**
![image](https://user-images.githubusercontent.com/50255197/137396707-465b589b-1a35-4e6f-9401-14bd6225e568.png)

### Long H2
**Before**
![long h2](https://user-images.githubusercontent.com/50255197/137396509-a46a0e55-2b7d-4a42-bfad-7764c1966c91.png)
**After**
I admit this doesn't look great, but it at least keeps the entire page from horizontally scrolling and can be resolved by adjusting the length of the H2s.
![image](https://user-images.githubusercontent.com/50255197/137396736-9b60ea4e-d5be-459e-bbeb-bc5c5d7e94d1.png)
