### PR TITLE
fix: Typo - sentence repetition in the paragraph

### DIFF
--- a/src/posts/Rename  Destructure Variables in ES6/Rename  Destructure Variables in ES6.mdx
+++ b/src/posts/Rename  Destructure Variables in ES6/Rename  Destructure Variables in ES6.mdx
@@ -29,7 +29,7 @@ const wes = {
 };
 ```
 
-For example here, I already used twitter as a variable. I can't use it again, but I'm stuck, because this object gives me twitter as a key and this object gives me twitter as a key. What you can do is you can rename them as you destructure them.
+For example here, I already used twitter as a variable. I can't use it again, but I'm stuck, because this object gives me twitter as a key. What you can do is you can rename them as you destructure them.
 
 So - I want the `twitter property, but I want to call it tweet. I want the facebook property, but I want to call it fb`.
 


### PR DESCRIPTION
The same sentence was repeated twice so I removed the repetition. ✌🏻

[link to the article](https://wesbos.com/destructuring-renaming) - 2nd paragraph

