### PR TITLE
fix width for ultra-wide class in layout.js

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -18,7 +18,7 @@ const ContentStyles = styled.div`
     max-width: 1000px;
   }
   &.ultra-wide {
-    max-width: 1800px;
+    max-width: 930px;
   }
 `;
 


### PR DESCRIPTION
I think it is best to minimize it a bit. Because in this case, it makes reading difficult on large screens
and unpleasant to read, especially while reading articles that take the appearance of a blog.
the value I think it should be 930px or 800px something like that