### PR TITLE
Fixes typo.

### DIFF
--- a/src/javascript/01-the-basics/01-welcome/01-welcome.mdx
+++ b/src/javascript/01-the-basics/01-welcome/01-welcome.mdx
@@ -61,4 +61,4 @@ If you understand certain concepts, such as what functions or parameters are, fe
 
 The whole idea is that it is reference-able.
 
-We are not building a huge app here that we build on in every video, instead, every video pretty much stands on it's own and if we reference something from a previous video, Wes will mention it.
+We are not building a huge app here that we build on in every video, instead, every video pretty much stands on its own and if we reference something from a previous video, Wes will mention it.


### PR DESCRIPTION
Not a native speaker but if i am not mistaken:
"it's" is short for "it is" and "its" is possessive form, so it should be used instead.