### PR TITLE
Update code snippet to remove deprecated command.

### DIFF
--- a/src/javascript/01-the-basics/05-code-quality-tooling-with-prettier-and-eslint/05-code-quality-tooling-with-prettier-and-eslint.mdx
+++ b/src/javascript/01-the-basics/05-code-quality-tooling-with-prettier-and-eslint/05-code-quality-tooling-with-prettier-and-eslint.mdx
@@ -272,7 +272,9 @@ The setting above 👆 is responsible for turning off formatting on save for Jav
 This setting below is responsible for telling the ESLint plugin to run on save. 👇
 
 ```json
-"eslint.autoFixOnSave": true
+"editor.codeActionsOnSave": {
+    "source.fixAll": true
+},
 ```
 
 You need to do that to prevent other built-in plugins in VS Code from clashing with our ESLint plugin.


### PR DESCRIPTION
A little update 😄 

`"eslint.autoFixOnSave": true,` has been deprecated, so the new action is 
` "editor.codeActionsOnSave": {
        "source.fixAll": true
    },
`
The eslint-config repo is correct just not the written beginner JS notes.