### PR TITLE
Fix: change '[pepperoni]' to  ['pepperoni']

### DIFF
--- a/src/javascript/12-advanced-flow-control/67-promises/67-promises.mdx
+++ b/src/javascript/12-advanced-flow-control/67-promises/67-promises.mdx
@@ -100,7 +100,7 @@ function makePizza(toppings) {
   return pizzaPromise;
 }
 
-const pepperoniPromise = makePizza('[pepperoni]');
+const pepperoniPromise = makePizza(['pepperoni']);
 const canadianPromise = makePizza(['pepperoni', 'mushroom', 'onions'])
 
 console.log(pepperoniPromise, canadianPromise);


### PR DESCRIPTION
The current demo code example results in error. It is currently a string. It should be an array containing a string.