### PR TITLE
upgrade node runtime with puppeteer

### DIFF
--- a/functions/ogimage/ogimage.js
+++ b/functions/ogimage/ogimage.js
@@ -41,6 +41,7 @@ async function getScreenshot(url, isDev) {
   const buffer = await page.screenshot({ type: 'png' });
   const base64Image = buffer.toString('base64');
   cached.set(url, base64Image);
+  console.log(base64Image);
   return base64Image;
 }
 

--- a/functions/ogimage/ogimage.js
+++ b/functions/ogimage/ogimage.js
@@ -1,6 +1,6 @@
-const chrome = require('chrome-aws-lambda');
+// const chrome = require('chrome-aws-lambda');
 // Switch to this, re: https://answers.netlify.com/t/netlify-function-with-puppeteer-breaks-if-i-make-any-changes/76924/8
-// const chrome = require('@sparticuz/chromium');
+const chrome = require('@sparticuz/chromium');
 const puppeteer = require('puppeteer-core');
 const wait = require('waait');
 

--- a/functions/ogimage/package-lock.json
+++ b/functions/ogimage/package-lock.json
@@ -9,9 +9,31 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "chrome-aws-lambda": "^10.1.0",
+        "@sparticuz/chromium": "92.0.0",
         "puppeteer-core": "^10.1.0",
         "waait": "^1.0.5"
+      }
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "92.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-92.0.0.tgz",
+      "integrity": "sha512-xCFop83v5gXKQTDGNfzj84F4f9QZkY9eShTu1pbWYOPB6wJNw9YgoX56zeVeRD7VL9AVwiS9VS9tgShnc5uR2g==",
+      "dependencies": {
+        "tar-fs": "^2.1.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sparticuz/chromium/node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
       }
     },
     "node_modules/@types/node": {
@@ -118,20 +140,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-    },
-    "node_modules/chrome-aws-lambda": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-10.1.0.tgz",
-      "integrity": "sha512-NZQVf+J4kqG4sVhRm3WNmOfzY0OtTSm+S8rg77pwePa9RCYHzhnzRs8YvNI6L9tALIW6RpmefWiPURt3vURXcw==",
-      "dependencies": {
-        "lambdafs": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 10.16"
-      },
-      "peerDependencies": {
-        "puppeteer-core": "^10.1.0"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -294,214 +302,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/lambdafs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-2.1.1.tgz",
-      "integrity": "sha512-x5k8JcoJWkWLvCVBzrl4pzvkEHSgSBqFjg3Dpsc4AcTMq7oUMym4cL/gRTZ6VM4mUMY+M0dIbQ+V1c1tsqqanQ==",
-      "bundleDependencies": [
-        "tar-fs"
-      ],
-      "dependencies": {
-        "tar-fs": "*"
-      },
-      "bin": {
-        "lambdafs": "bin/brotli.js"
-      },
-      "engines": {
-        "node": ">= 10.16"
-      }
-    },
-    "node_modules/lambdafs/node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/lambdafs/node_modules/bl": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/lambdafs/node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/lambdafs/node_modules/buffer": {
-      "version": "5.7.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/lambdafs/node_modules/chownr": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/lambdafs/node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/lambdafs/node_modules/fs-constants": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/lambdafs/node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/lambdafs/node_modules/inherits": {
-      "version": "2.0.4",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/lambdafs/node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/lambdafs/node_modules/once": {
-      "version": "1.4.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/lambdafs/node_modules/pump": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/lambdafs/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/lambdafs/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/lambdafs/node_modules/tar-fs": {
-      "version": "2.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/lambdafs/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lambdafs/node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/lambdafs/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/lambdafs/node_modules/wrappy": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -542,6 +342,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -813,6 +618,27 @@
     }
   },
   "dependencies": {
+    "@sparticuz/chromium": {
+      "version": "92.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-92.0.0.tgz",
+      "integrity": "sha512-xCFop83v5gXKQTDGNfzj84F4f9QZkY9eShTu1pbWYOPB6wJNw9YgoX56zeVeRD7VL9AVwiS9VS9tgShnc5uR2g==",
+      "requires": {
+        "tar-fs": "^2.1.1"
+      },
+      "dependencies": {
+        "tar-fs": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "mkdirp-classic": "^0.5.2",
+            "pump": "^3.0.0",
+            "tar-stream": "^2.1.4"
+          }
+        }
+      }
+    },
     "@types/node": {
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
@@ -883,14 +709,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-    },
-    "chrome-aws-lambda": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-10.1.0.tgz",
-      "integrity": "sha512-NZQVf+J4kqG4sVhRm3WNmOfzY0OtTSm+S8rg77pwePa9RCYHzhnzRs8YvNI6L9tALIW6RpmefWiPURt3vURXcw==",
-      "requires": {
-        "lambdafs": "^2.0.3"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1005,143 +823,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "lambdafs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-2.1.1.tgz",
-      "integrity": "sha512-x5k8JcoJWkWLvCVBzrl4pzvkEHSgSBqFjg3Dpsc4AcTMq7oUMym4cL/gRTZ6VM4mUMY+M0dIbQ+V1c1tsqqanQ==",
-      "requires": {
-        "tar-fs": "*"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "bl": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            }
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "bundled": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "chownr": {
-          "version": "1.1.4",
-          "bundled": true
-        },
-        "end-of-stream": {
-          "version": "1.4.4",
-          "bundled": true,
-          "requires": {
-            "once": "^1.4.0"
-          }
-        },
-        "fs-constants": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "mkdirp-classic": {
-          "version": "0.5.3",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "tar-fs": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^2.1.4"
-          }
-        },
-        "tar-stream": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
-    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1170,6 +851,11 @@
       "requires": {
         "minimist": "^1.2.6"
       }
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "ms": {
       "version": "2.1.2",
@@ -1357,7 +1043,8 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     },
     "yauzl": {
       "version": "2.10.0",

--- a/functions/ogimage/package.json
+++ b/functions/ogimage/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chrome-aws-lambda": "^10.1.0",
+    "@sparticuz/chromium": "92.0.0",
     "puppeteer-core": "^10.1.0",
     "waait": "^1.0.5"
   }


### PR DESCRIPTION
I ran out of time and aws dropped node 12. Which means I need to upgrade to a newer version of chrome-aws-lambda, which is too large for a function. 

This fix: https://github.com/Sparticuz/chromium/issues/8