### PR TITLE
Update 18-hoisting.mdx

### DIFF
--- a/src/javascript/03-the-tricky-bits/18-hoisting/18-hoisting.mdx
+++ b/src/javascript/03-the-tricky-bits/18-hoisting/18-hoisting.mdx
@@ -160,4 +160,4 @@ Only function declaration types of functions are hoisted, **not** function expre
 
 Same thing goes with arrow function or any other type of function.
 
-It is important to note that although **let** and **const** variables are hoisted, they are not initialised to `undefined`, unlike **var** variables. Hence, in the above example if you replace var with let or const, you would be presented with a `ReferenceError` saying - `age is not defined`
+It is important to note that although **let** and **const** variables are hoisted, they are not initialised to `undefined`, unlike **var** variables. Hence, in the above example if you replace var with let or const, you would be presented with a `ReferenceError` saying - `Cannot access 'age' before initialization`


### PR DESCRIPTION
fix wrong reference error message

when we declare a variable with let / const, it is hoisted but gives a reference error (when referenced before value assignment), but this reference error is different from the one which appears if we try to refer to a non-existen variable (`<x> is not defined`)

instead it shows the message `Cannot access '<x>' before initialization`