### PR TITLE
Typo: In a code section inside 29-event-listener.mdx

### DIFF
--- a/src/javascript/05-events/29-event-listener/29-event-listener.mdx
+++ b/src/javascript/05-events/29-event-listener/29-event-listener.mdx
@@ -194,7 +194,7 @@ If you ever in the future need to remove an event listener, **remember not to us
 
 ```js
 const hooray = () => console.log("HOORAY!");
-coolButton.addEventLustener('click', hooray);
+coolButton.addEventListener('click', hooray);
 ```
 
 Shown above 👆is how you would add an event listener with an arrow function.


### PR DESCRIPTION
Fix typo in `29-event-listener.mdx`

Changes 
```js
coolButton.addEventLustener('click', hooray);
```
 to 
```js
coolButton.addEventListener('click', hooray);`
```

In Module 5 -> Event listener -> Removing an event listener -> # Listening to events on multiple elements