### PR TITLE
Added call to inner(). Without it, nothing is logged to the console.

### DIFF
--- a/src/content/javascript/03-the-tricky-bits/19-closures/19-closures.mdx
+++ b/src/content/javascript/03-the-tricky-bits/19-closures/19-closures.mdx
@@ -70,6 +70,8 @@ Since there is no variable called `outerVar` in that function, it will go a leve
       console.log(innerVar);
       console.log(outerVar);
     }
+
+    inner();
   }
 ```
 


### PR DESCRIPTION
This change adds the missing call to `inner()` inside `outer()` so that both variables (`innerVar` and `outerVar`) are logged to the console as described in the accompanying text. Without this, nothing is logged, which could confuse readers.
